### PR TITLE
fix: 新增本地游戏后卡片仍显示为灰色

### DIFF
--- a/GalgameManager.Test/Helpers/GameToOpacityConverterTest.cs
+++ b/GalgameManager.Test/Helpers/GameToOpacityConverterTest.cs
@@ -1,0 +1,25 @@
+using GalgameManager.Helpers.Converter;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameToOpacityConverterTest
+{
+    [TearDown]
+    public void TearDown()
+    {
+        GameToOpacityConverter.SpecialDisplayVirtualGame = false;
+    }
+
+    [TestCase(true, 1d)]
+    [TestCase(false, 0.5d)]
+    public void Convert_UsesCurrentLocalGameState(bool isLocalGame, double expectedOpacity)
+    {
+        GameToOpacityConverter.SpecialDisplayVirtualGame = true;
+        GameToOpacityConverter converter = new();
+
+        object result = converter.Convert(isLocalGame, typeof(double), null!, string.Empty);
+
+        Assert.That(result, Is.EqualTo(expectedOpacity));
+    }
+}

--- a/GalgameManager/Helpers/Converter/GameToOpacityConverter.cs
+++ b/GalgameManager/Helpers/Converter/GameToOpacityConverter.cs
@@ -9,7 +9,9 @@ public class GameToOpacityConverter : IValueConverter
     
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        if (value is Galgame game)
+        if (value is bool isLocalGame)
+            return SpecialDisplayVirtualGame && !isLocalGame ? 0.5 : 1;
+        if (value is Galgame game) // Compatibility with other existing bindings.
             return SpecialDisplayVirtualGame && !game.IsLocalGame ? 0.5 : 1;
         return 1.0;
     }

--- a/GalgameManager/ViewModels/HomeViewModel.cs
+++ b/GalgameManager/ViewModels/HomeViewModel.cs
@@ -1293,7 +1293,8 @@ public partial class HomeViewModel : ObservableObject, INavigationAware
     {
         _localSettingsService.SaveSettingAsync(KeyValues.SpecialDisplayVirtualGame, value);
         GameToOpacityConverter.SpecialDisplayVirtualGame = value;
-        Source.Refresh();
+        foreach (Galgame game in _galgameService.Galgames)
+            game.RaisePropertyChanged(nameof(Galgame.IsLocalGame));
     }
 }
 

--- a/GalgameManager/Views/Prefab/GalgamePrefab.xaml
+++ b/GalgameManager/Views/Prefab/GalgamePrefab.xaml
@@ -18,7 +18,7 @@
           ContextFlyout="{x:Bind Flyout, Mode=OneWay}" Padding="{StaticResource XSmallLeftTopRightBottomMargin}">
         <StackPanel HorizontalAlignment="Center">
             <Grid
-                Opacity="{x:Bind Galgame, Mode=OneWay,
+                Opacity="{x:Bind Galgame.IsLocalGame, Mode=OneWay,
                             Converter={StaticResource GameToOpacityConverter}}"
                 x:Name="ConnectedElement"
                 CornerRadius="10">


### PR DESCRIPTION
## 问题

开启“特殊显示非本地游戏”后，新添加的本地游戏可能一直以半透明状态显示，直到页面被重新创建。关闭该设置也不能保证现有卡片立即刷新。
<img width="1264" height="744" alt="图片" src="https://github.com/user-attachments/assets/4a1e1097-2ce0-48bc-858d-b2c628515540" />

## 原因

游戏卡片将整个 `Galgame` 对象传给 `GameToOpacityConverter`。添加流程中，`SourceEntries` 稍后才绑定到本地来源；虽然 `Galgame.IsLocalGame` 会发送属性变化通知，但对象引用没有变化，转换器不会重新执行，因此保留了添加早期的非本地游戏透明度。

## 修改

- 卡片透明度直接绑定 `Galgame.IsLocalGame`。
- 转换器支持布尔状态，同时保留对旧 `Galgame` 输入的兼容处理。
- 切换“特殊显示非本地游戏”时，通知现有游戏重新计算 `IsLocalGame` 绑定。
- 增加转换器单元测试。

## 测试

- `dotnet test GalgameManager.Test/GalgameManager.Test.csproj --no-restore --filter "FullyQualifiedName~GameToOpacityConverterTest"`
- 结果：2/2 通过。
- 实机验证：连续添加两个本地游戏后，两张卡片都会恢复为正常不透明状态。
<img width="1174" height="744" alt="图片" src="https://github.com/user-attachments/assets/90c7443c-5a7e-4435-adc0-20ce577fd747" />

