### PR TITLE
fix: 避免同一天重复导出时文件名冲突

### DIFF
--- a/GalgameManager.Test/Models/ExportTaskTest.cs
+++ b/GalgameManager.Test/Models/ExportTaskTest.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using GalgameManager.Models.BgTasks;
+
+namespace GalgameManager.Test.Models;
+
+[TestFixture]
+public class ExportTaskTest
+{
+    [Test]
+    public void CreateFileName_IncludesTimeToSeconds()
+    {
+        MethodInfo method = typeof(ExportTask).GetMethod(
+            "CreateFileName",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        string actual = (string)method.Invoke(null, [new DateTime(2026, 8, 19, 22, 34, 31)])!;
+
+        Assert.That(actual, Is.EqualTo("PotatoVN_26-08-19_22-34-31.pvnExport.zip"));
+    }
+}

--- a/GalgameManager/Models/BgTasks/ExportTask.cs
+++ b/GalgameManager/Models/BgTasks/ExportTask.cs
@@ -16,7 +16,7 @@ public class ExportTask (string targetPath) : BgTaskBase
     private readonly ICategoryService _categoryService = App.GetService<ICategoryService>();
     private readonly IStaffService _staffService = App.GetService<IStaffService>();
     private readonly IFileService _fileService = App.GetService<IFileService>();
-    private readonly string _fileName = $"PotatoVN_{DateTime.Now:yy-MM-dd}.pvnExport.zip";
+    private readonly string _fileName = CreateFileName(DateTime.Now);
     
     protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
     
@@ -89,6 +89,9 @@ public class ExportTask (string targetPath) : BgTaskBase
     public override string Title => "ExportTask_Title".GetLocalized();
     
     public override bool OnSearch(string key) => true;
+
+    private static string CreateFileName(DateTime timestamp) =>
+        $"PotatoVN_{timestamp:yy-MM-dd_HH-mm-ss}.pvnExport.zip";
     
     private string OutputFilePath => $"{TargetPath}\\{_fileName}";
 }


### PR DESCRIPTION
自动导出的间隔可以小于 24 小时，再加上手动导出，一天内可能产生多份导出数据。

原来的文件名只精确到日期，因此当天第二次导出时会因为文件已存在而失败。

<img width="1265" height="760" alt="同一天重复导出时发生文件名冲突" src="https://github.com/user-attachments/assets/4baa7ff2-5681-4531-b0d9-44c8a0514c00" />

这次将文件名改为：

PotatoVN_yy-MM-dd_HH-mm-ss.pvnExport.zip

例如：`PotatoVN_26-08-19_22-34-31.pvnExport.zip`。

<img width="431" height="64" alt="修复后同一天生成的两个导出文件" src="https://github.com/user-attachments/assets/1ea18054-806e-4d41-ad30-50502d7726fa" />

## 测试

- `ExportTaskTest` 通过。
- 在本地测试版中连续导出两次，两个文件均正常生成。