### PR TITLE
fix: 避免重复启动同一游戏时产生多个计时任务

### DIFF
--- a/GalgameManager.Test/Services/BgTaskServiceTest.cs
+++ b/GalgameManager.Test/Services/BgTaskServiceTest.cs
@@ -84,6 +84,66 @@ public class BgTaskServiceTest : ServiceTestBase
         await addTask;
     }
 
+    [Test]
+    public async Task AddBgTask_ConcurrentDuplicates_OnlyOneRuns()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask[] tasks = Enumerable.Range(0, 32)
+            .Select(_ => new DeduplicatedTestBgTask("same", gate))
+            .ToArray();
+        var addedCount = 0;
+        service.BgTaskAdded += _ => Interlocked.Increment(ref addedCount);
+
+        Task[] additions = tasks.Select(service.AddBgTask).ToArray();
+        await Task.Delay(100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.GetBgTasks().Count(), Is.EqualTo(1));
+            Assert.That(tasks.Count(task => task.Ran), Is.EqualTo(1));
+            Assert.That(addedCount, Is.EqualTo(1));
+        });
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
+    [Test]
+    public async Task AddBgTask_DuplicateAfterCompletion_RunsAgain()
+    {
+        BgTaskService service = CreateService();
+        DeduplicatedTestBgTask first = new("same");
+        DeduplicatedTestBgTask second = new("same");
+
+        await service.AddBgTask(first);
+        await service.AddBgTask(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Ran, Is.True);
+            Assert.That(second.Ran, Is.True);
+            Assert.That(service.GetBgTasks(), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AddBgTask_DifferentDeduplicationKeys_RunTogether()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask first = new("first", gate);
+        DeduplicatedTestBgTask second = new("second", gate);
+
+        Task[] additions = [service.AddBgTask(first), service.AddBgTask(second)];
+        await Task.Delay(100);
+
+        Assert.That(service.GetBgTasks().Count(), Is.EqualTo(2));
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
     // 验证后台任务的持久化与恢复闭环：SaveBgTasksString把运行中的任务写入文件，
     // 新实例ResolvedBgTasksAsync读回、反序列化、RecoverFromJson并重新运行，最后删除文件
     [Test]
@@ -118,6 +178,34 @@ public class BgTaskServiceTest : ServiceTestBase
         // 等恢复的任务跑完并从列表移除，避免残留状态影响后续用例
         await Task.Delay(800);
         Assert.That(service2.GetBgTasks(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Resolve_DuplicatePersistedTasks_OnlyOneIsRestored()
+    {
+        RecoverableDeduplicatedTestBgTask.Reset();
+        BgTaskService service = CreateService();
+        service.RegisterBgTaskType(typeof(RecoverableDeduplicatedTestBgTask), "-dedupe");
+        string json = JsonConvert.SerializeObject(new RecoverableDeduplicatedTestBgTask
+        {
+            Key = "same",
+        });
+        string persisted = $"-dedupe {json.ToBase64()} -dedupe {json.ToBase64()} ";
+        _fileService.Save(AppStoragePaths.LocalDataPath, BgTaskFileName, persisted);
+        string file = Path.Combine(AppStoragePaths.LocalDataPath, BgTaskFileName);
+        for (var i = 0; i < 50 && !File.Exists(file); i++) await Task.Delay(100);
+
+        await service.ResolvedBgTasksAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RecoverableDeduplicatedTestBgTask.RunCount, Is.EqualTo(1));
+            Assert.That(service.GetBgTasks().OfType<RecoverableDeduplicatedTestBgTask>().Count(), Is.EqualTo(1));
+        });
+
+        RecoverableDeduplicatedTestBgTask.Gate.SetResult();
+        await Task.Delay(800);
+        Assert.That(service.GetBgTasks(), Is.Empty);
     }
 
     public class TestBgTask : BgTaskBase
@@ -160,5 +248,55 @@ public class BgTaskServiceTest : ServiceTestBase
         protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
 
         protected override Task RunInternal() => Task.CompletedTask;
+    }
+
+    public class DeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        private readonly TaskCompletionSource? _gate;
+
+        public DeduplicatedTestBgTask(string key, TaskCompletionSource? gate = null)
+        {
+            DeduplicationKey = key;
+            _gate = gate;
+        }
+
+        public string? DeduplicationKey { get; }
+        public bool Ran { get; private set; }
+        public override string Title => "DeduplicatedTestBgTask";
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Ran = true;
+            if (_gate is not null) await _gate.Task;
+        }
+    }
+
+    public class RecoverableDeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        public static TaskCompletionSource Gate { get; private set; } = NewGate();
+        public static int RunCount;
+
+        public string? Key { get; set; }
+        public string? DeduplicationKey => Key;
+        public override string Title => "RecoverableDeduplicatedTestBgTask";
+
+        public static void Reset()
+        {
+            Gate = NewGate();
+            RunCount = 0;
+        }
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Interlocked.Increment(ref RunCount);
+            await Gate.Task;
+        }
+
+        private static TaskCompletionSource NewGate() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
+++ b/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
@@ -1,0 +1,12 @@
+namespace GalgameManager.Models.BgTasks;
+
+/// <summary>
+/// 标记活动期间必须保持逻辑唯一的后台任务。
+/// </summary>
+public interface IDeduplicatedBgTask
+{
+    /// <summary>
+    /// 获取任务类型内的逻辑标识；空值表示不启用去重。
+    /// </summary>
+    string? DeduplicationKey { get; }
+}

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -12,7 +12,7 @@ using GalgameManager.WinApp.Base.Models.Msgs;
 
 namespace GalgameManager.Models.BgTasks;
 
-public class RecordPlayTimeTask : BgTaskBase
+public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 {
     private const int ManuallySelectProcessSec = 15; //认定为需要手动选择游戏进程的时间阈值
 
@@ -21,6 +21,7 @@ public class RecordPlayTimeTask : BgTaskBase
     public int CurrentPlayTime { get; set; } //本次游玩时间
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
     public override bool ProgressOnTrayIcon => true;
+    public string? DeduplicationKey => Galgame?.Uuid.ToString("D");
 
     public Galgame? Galgame;
     private Process? _process;
@@ -206,6 +207,9 @@ public class RecordPlayTimeTask : BgTaskBase
             }
         });
     }
+
+    public override bool OnSearch(string key) =>
+        Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Services/BgTaskService.cs
+++ b/GalgameManager/Services/BgTaskService.cs
@@ -131,9 +131,29 @@ public class BgTaskService : IBgTaskService
     {
         try
         {
+            string? rejectedDuplicateKey = null;
             lock (_bgTasksLock)
             {
-                _bgTasks.Add(bgTask);
+                if (bgTask is IDeduplicatedBgTask { DeduplicationKey: { Length: > 0 } key } &&
+                    _bgTasks.Any(existing => existing.GetType() == bgTask.GetType() &&
+                                             existing is IDeduplicatedBgTask deduplicated &&
+                                             string.Equals(deduplicated.DeduplicationKey, key,
+                                                 StringComparison.Ordinal)))
+                {
+                    rejectedDuplicateKey = key;
+                }
+                else
+                {
+                    _bgTasks.Add(bgTask);
+                }
+            }
+
+            if (rejectedDuplicateKey is not null)
+            {
+                _infoService.DeveloperEvent(
+                    msg: $"Ignored duplicate background task: type={bgTask.GetType().Name}, " +
+                         $"key={rejectedDuplicateKey}");
+                return Task.CompletedTask;
             }
 
             if (bgTask.ProgressOnTrayIcon)

--- a/GalgameManager/Services/BgTaskService.cs
+++ b/GalgameManager/Services/BgTaskService.cs
@@ -132,9 +132,29 @@ public class BgTaskService : IBgTaskService
     {
         try
         {
+            string? rejectedDuplicateKey = null;
             lock (_bgTasksLock)
             {
-                _bgTasks.Add(bgTask);
+                if (bgTask is IDeduplicatedBgTask { DeduplicationKey: { Length: > 0 } key } &&
+                    _bgTasks.Any(existing => existing.GetType() == bgTask.GetType() &&
+                                             existing is IDeduplicatedBgTask deduplicated &&
+                                             string.Equals(deduplicated.DeduplicationKey, key,
+                                                 StringComparison.Ordinal)))
+                {
+                    rejectedDuplicateKey = key;
+                }
+                else
+                {
+                    _bgTasks.Add(bgTask);
+                }
+            }
+
+            if (rejectedDuplicateKey is not null)
+            {
+                _infoService.DeveloperEvent(
+                    msg: $"Ignored duplicate background task: type={bgTask.GetType().Name}, " +
+                         $"key={rejectedDuplicateKey}");
+                return Task.CompletedTask;
             }
 
             if (bgTask.ProgressOnTrayIcon)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -26,6 +26,8 @@ public sealed class GameLaunchService(
     : IGameLaunchService
 {
     private static readonly TimeSpan ProcessWaitTimeout = TimeSpan.FromSeconds(60); // 等待目标游戏进程出现的最长时间
+    private readonly object _launchStateLock = new();
+    private readonly HashSet<Guid> _launchesInProgress = [];
     private readonly GalgameCollectionService _gameService =
         (GalgameCollectionService)gameCollectionService; // 逻辑游戏持久化与可执行文件选择服务
 
@@ -34,6 +36,35 @@ public sealed class GameLaunchService(
     {
         if (installation.Galgame != game || !installation.IsLocalInstallation)
             throw new ArgumentException("The installation does not belong to the game.", nameof(installation));
+
+        if (!TryEnterLaunch(game.Uuid))
+        {
+            ReportDuplicateLaunch(game, "launch request already in progress");
+            return;
+        }
+
+        try
+        {
+            await LaunchCoreAsync(game, installation);
+        }
+        finally
+        {
+            lock (_launchStateLock)
+            {
+                _launchesInProgress.Remove(game.Uuid);
+            }
+        }
+    }
+
+    private async Task LaunchCoreAsync(Galgame game, GalgameAndPath installation)
+    {
+        string gameKey = game.Uuid.ToString("D");
+        if (bgTaskService.GetBgTask<RecordPlayTimeTask>(gameKey) is not null)
+        {
+            ReportDuplicateLaunch(game, "play-time task already active");
+            return;
+        }
+
         if (!Directory.Exists(installation.Path))
         {
             infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
@@ -187,6 +218,22 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+    }
+
+    private bool TryEnterLaunch(Guid gameId)
+    {
+        lock (_launchStateLock)
+        {
+            return _launchesInProgress.Add(gameId);
+        }
+    }
+
+    private void ReportDuplicateLaunch(Galgame game, string reason)
+    {
+        infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            msg: "GalgamePage_Play_AlreadyRunning".GetLocalized(game.Name.Value ?? string.Empty));
+        infoService.Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -26,6 +26,8 @@ public sealed class GameLaunchService(
     : IGameLaunchService
 {
     private static readonly TimeSpan ProcessWaitTimeout = TimeSpan.FromSeconds(60); // 等待目标游戏进程出现的最长时间
+    private readonly object _launchStateLock = new();
+    private readonly HashSet<Guid> _launchesInProgress = [];
     private readonly GalgameCollectionService _gameService =
         (GalgameCollectionService)gameCollectionService; // 逻辑游戏持久化与可执行文件选择服务
 
@@ -34,6 +36,35 @@ public sealed class GameLaunchService(
     {
         if (installation.Galgame != game || !installation.IsLocalInstallation)
             throw new ArgumentException("The installation does not belong to the game.", nameof(installation));
+
+        if (!TryEnterLaunch(game.Uuid))
+        {
+            ReportDuplicateLaunch(game, "launch request already in progress");
+            return;
+        }
+
+        try
+        {
+            await LaunchCoreAsync(game, installation);
+        }
+        finally
+        {
+            lock (_launchStateLock)
+            {
+                _launchesInProgress.Remove(game.Uuid);
+            }
+        }
+    }
+
+    private async Task LaunchCoreAsync(Galgame game, GalgameAndPath installation)
+    {
+        string gameKey = game.Uuid.ToString("D");
+        if (bgTaskService.GetBgTask<RecordPlayTimeTask>(gameKey) is not null)
+        {
+            ReportDuplicateLaunch(game, "play-time task already active");
+            return;
+        }
+
         if (!Directory.Exists(installation.Path))
         {
             infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
@@ -178,6 +209,22 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+    }
+
+    private bool TryEnterLaunch(Guid gameId)
+    {
+        lock (_launchStateLock)
+        {
+            return _launchesInProgress.Add(gameId);
+        }
+    }
+
+    private void ReportDuplicateLaunch(Galgame game, string reason)
+    {
+        infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            msg: "GalgamePage_Play_AlreadyRunning".GetLocalized(game.Name.Value ?? string.Empty));
+        infoService.Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName)

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4084,4 +4084,7 @@ If play time can record correctly, just cancel this popup.
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>Wheel up</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>Wheel down</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>Mouse button {0}</value></data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}” is already running or its play time is being recorded.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4147,4 +4147,7 @@ If play time can record correctly, just cancel this popup.
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>No target library available. Add another library first.</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}” is already running or its play time is being recorded.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4010,4 +4010,7 @@
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>ホイール上</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>ホイール下</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>マウスボタン {0}</value></data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4076,4 +4076,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>移動先のライブラリがありません。先に別のライブラリを追加してください。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4998,4 +4998,7 @@
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>滚轮向上</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>滚轮向下</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>鼠标按键 {0}</value></data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}”已在运行或正在记录游玩时间。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5059,4 +5059,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>没有可移动到的目标库，请先添加另一个库。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}”已在运行或正在记录游玩时间。</value>
+  </data>
 </root>


### PR DESCRIPTION
对于手动指定进程的游戏，连续点击启动时，后一次启动即使没有真正拉起新的游戏进程，也可能再次找到已经运行的进程，并创建新的游玩计时任务。后台会因此同时出现两个甚至更多计时任务，最终导致游玩时间重复累计。

<img width="1264" height="744" alt="重复启动后后台出现多个计时任务" src="https://github.com/user-attachments/assets/edf623d6-4954-4a14-a090-412acc21a68f" />

本次修改：

- 同一个游戏已有启动流程或计时任务时，不再重复启动，并给出提示。
- 后台任务支持按逻辑键去重，游玩计时任务使用游戏 UUID 作为键。
- “检查重复”和“加入任务”在同一把锁内完成，避免连续点击或并发调用绕过去重。
- 从托盘恢复持久化任务时也会去重。
- 原任务结束后可以再次正常启动游戏，不同游戏之间互不影响。

<img width="1264" height="744" alt="已修正" src="https://github.com/user-attachments/assets/5cbe40ed-7d79-4ce4-8213-a28f92938174" />

## 测试

- `BgTaskServiceTest` 通过。
- 在本地测试版中连续启动同一游戏，后台不再出现多个计时任务。