### PR TITLE
fix: 让按键映射修改立即应用

### DIFF
--- a/GalgameManager.Test/Helpers/KeyMappingMergeHelperTest.cs
+++ b/GalgameManager.Test/Helpers/KeyMappingMergeHelperTest.cs
@@ -164,6 +164,18 @@ public class KeyMappingMergeHelperTest
         });
     }
 
+    [TestCase(1, 0x01)]
+    [TestCase(2, 0x02)]
+    [TestCase(3, 0x04)]
+    [TestCase(4, 0x05)]
+    [TestCase(5, 0x06)]
+    [TestCase(6, 0)]
+    [TestCase(7, 0)]
+    public void GetMouseButtonVirtualKey_ConvertsInternalButtonCodes(int mouseButton, int expected)
+    {
+        Assert.That(KeyMappingMergeHelper.GetMouseButtonVirtualKey(mouseButton), Is.EqualTo(expected));
+    }
+
     private static KeyMapping Mapping(VirtualKey from, VirtualKey to, bool isGlobal = false) => new()
     {
         From = [(int)from],

--- a/GalgameManager.Test/Helpers/KeyMappingRuntimeSnapshotTest.cs
+++ b/GalgameManager.Test/Helpers/KeyMappingRuntimeSnapshotTest.cs
@@ -9,7 +9,7 @@ namespace GalgameManager.Test.Helpers;
 public class KeyMappingRuntimeSnapshotTest
 {
     [Test]
-    public void BuildEffectiveMappings_Preserves618OptInSemantics()
+    public void BuildEffectiveMappings_PreservesExistingOptInSemantics()
     {
         KeyMapping game = Mapping(VirtualKey.A, VirtualKey.Space);
         KeyMapping global = Mapping(VirtualKey.B, VirtualKey.Enter, isGlobal: true);

--- a/GalgameManager.Test/Helpers/KeyMappingRuntimeSnapshotTest.cs
+++ b/GalgameManager.Test/Helpers/KeyMappingRuntimeSnapshotTest.cs
@@ -1,0 +1,106 @@
+using GalgameManager.Helpers;
+using GalgameManager.Models;
+using GalgameManager.WinApp.Base.Models.Msgs;
+using Windows.System;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class KeyMappingRuntimeSnapshotTest
+{
+    [Test]
+    public void BuildEffectiveMappings_Preserves618OptInSemantics()
+    {
+        KeyMapping game = Mapping(VirtualKey.A, VirtualKey.Space);
+        KeyMapping global = Mapping(VirtualKey.B, VirtualKey.Enter, isGlobal: true);
+
+        List<KeyMapping> none = KeyMappingRuntimeSnapshot.BuildEffectiveMappings([game], [global], false, false);
+        List<KeyMapping> gameOnly = KeyMappingRuntimeSnapshot.BuildEffectiveMappings([game], [global], true, false);
+        List<KeyMapping> globalOnly = KeyMappingRuntimeSnapshot.BuildEffectiveMappings([game], [global], false, true);
+        List<KeyMapping> both = KeyMappingRuntimeSnapshot.BuildEffectiveMappings([game], [global], true, true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(none, Is.Empty);
+            Assert.That(gameOnly.Select(item => item.From.Single()),
+                Is.EquivalentTo(new[] { (int)VirtualKey.A, (int)VirtualKey.B }));
+            Assert.That(globalOnly.Select(item => item.From.Single()),
+                Is.EquivalentTo(new[] { (int)VirtualKey.A, (int)VirtualKey.B }));
+            Assert.That(both.Select(item => item.From.Single()),
+                Is.EquivalentTo(new[] { (int)VirtualKey.A, (int)VirtualKey.B }));
+        });
+    }
+
+    [Test]
+    public void Create_ClonesRulesBeforePublishingSnapshot()
+    {
+        KeyMapping mapping = Mapping(VirtualKey.A, VirtualKey.Space);
+        KeyMappingRuntimeSnapshot snapshot = KeyMappingRuntimeSnapshot.Create([mapping]);
+        string signature = KeyMappingMergeHelper.CreateSourceSignature([(int)VirtualKey.A]);
+
+        mapping.From[0] = (int)VirtualKey.B;
+        mapping.To[0] = (int)VirtualKey.Enter;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.LookupMap.ContainsKey(signature), Is.True);
+            Assert.That(snapshot.LookupMap[signature].Key, Is.EqualTo((int)VirtualKey.Space));
+        });
+    }
+
+    [Test]
+    public void HeldInputGuard_RequiresKeyboardAndMouseReleaseAfterTransition()
+    {
+        KeyMappingHeldInputGuard guard = new();
+        guard.BeginTransition([(int)VirtualKey.LeftControl, (int)VirtualKey.A], [1]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.IsKeyboardSuppressed([(int)VirtualKey.LeftControl, (int)VirtualKey.B]), Is.True);
+            Assert.That(guard.IsMouseSuppressed(1, []), Is.True);
+            Assert.That(guard.IsMouseSuppressed(2, [(int)VirtualKey.LeftControl]), Is.True);
+        });
+
+        guard.ReleaseKeyboard((int)VirtualKey.LeftControl);
+        guard.ReleaseKeyboard((int)VirtualKey.A);
+        guard.ReleaseMouse(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.IsKeyboardSuppressed([(int)VirtualKey.LeftControl, (int)VirtualKey.B]), Is.False);
+            Assert.That(guard.IsMouseSuppressed(1, []), Is.False);
+            Assert.That(guard.IsMouseSuppressed(2, [(int)VirtualKey.LeftControl]), Is.False);
+        });
+    }
+
+    [Test]
+    public void KeyMappingsChangedMessage_CapturesSavedRulesInsteadOfSharingMutableGalgameState()
+    {
+        Galgame galgame = new()
+        {
+            KeyReMap = true,
+            KeyMappings = [Mapping(VirtualKey.A, VirtualKey.Space)],
+        };
+
+        KeyMappingsChangedMessage message = new(galgame);
+        galgame.KeyReMap = false;
+        galgame.KeyMappings[0].From[0] = (int)VirtualKey.B;
+        galgame.KeyMappings[0].To[0] = (int)VirtualKey.Enter;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(message.GalgameUuid, Is.EqualTo(galgame.Uuid));
+            Assert.That(message.GameMappingOptInEnabled, Is.True);
+            Assert.That(message.GameMappings.Single().From.Single(), Is.EqualTo((int)VirtualKey.A));
+            Assert.That(message.GameMappings.Single().To.Single(), Is.EqualTo((int)VirtualKey.Space));
+        });
+    }
+
+    private static KeyMapping Mapping(VirtualKey from, VirtualKey to, bool isGlobal = false) => new()
+    {
+        From = [(int)from],
+        To = [(int)to],
+        IsEnabled = true,
+        IsGlobal = isGlobal,
+    };
+}

--- a/GalgameManager.WinApp.Base/Models/Msgs/GalgameEvents.cs
+++ b/GalgameManager.WinApp.Base/Models/Msgs/GalgameEvents.cs
@@ -1,7 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using CommunityToolkit.Mvvm.Messaging.Messages;
 using GalgameManager.Models;
 
 namespace GalgameManager.WinApp.Base.Models.Msgs;
 
 public class GalgamePlayedMessage(Galgame galgame) : ValueChangedMessage<Galgame>(galgame);
+
+/// <summary>
+/// 将游戏已保存映射状态的不可变副本传递给正在运行的按键映射任务。
+/// </summary>
+public class KeyMappingsChangedMessage : AsyncRequestMessage<bool>
+{
+    public Guid GalgameUuid { get; }
+    public IReadOnlyList<KeyMapping> GameMappings { get; }
+    public bool GameMappingOptInEnabled { get; }
+
+    public KeyMappingsChangedMessage(Galgame galgame)
+    {
+        GalgameUuid = galgame.Uuid;
+        GameMappings = (galgame.KeyMappings ?? [])
+            .Select(Clone)
+            .ToArray();
+        GameMappingOptInEnabled = galgame.KeyReMap;
+    }
+
+    private static KeyMapping Clone(KeyMapping mapping) => new()
+    {
+        From = mapping.From is null ? [] : [.. mapping.From],
+        To = mapping.To is null ? [] : [.. mapping.To],
+        Remark = mapping.Remark ?? string.Empty,
+        IsEnabled = mapping.IsEnabled,
+        IsGlobal = mapping.IsGlobal,
+    };
+}
+
 public class GalgameStoppedMessage(Galgame galgame) : ValueChangedMessage<Galgame>(galgame);

--- a/GalgameManager/Helpers/KeyMappingMergeHelper.cs
+++ b/GalgameManager/Helpers/KeyMappingMergeHelper.cs
@@ -230,6 +230,19 @@ public static class KeyMappingMergeHelper
         return result;
     }
 
+    /// <summary>
+    /// 将按键映射使用的鼠标按钮编号转换为 GetAsyncKeyState 所需的虚拟键码。
+    /// </summary>
+    public static int GetMouseButtonVirtualKey(int mouseButton) => mouseButton switch
+    {
+        1 => 0x01,
+        2 => 0x02,
+        3 => 0x04,
+        4 => 0x05,
+        5 => 0x06,
+        _ => 0,
+    };
+
     private static bool IsMouseButtonCode(int key) => key is >= 1 and <= 7;
 
     private static bool ContainsSource(IEnumerable<List<int>> sources, IEnumerable<int> source) =>

--- a/GalgameManager/Helpers/KeyMappingRuntimeSnapshot.cs
+++ b/GalgameManager/Helpers/KeyMappingRuntimeSnapshot.cs
@@ -1,0 +1,93 @@
+using System.Collections.Frozen;
+using GalgameManager.Models;
+
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 构建完成后不再修改的运行时映射快照，供低级钩子回调无锁读取。
+/// </summary>
+public sealed class KeyMappingRuntimeSnapshot
+{
+    public static KeyMappingRuntimeSnapshot Empty { get; } = new([], []);
+
+    public FrozenDictionary<string, KeyMappingOutput> LookupMap { get; }
+    public FrozenDictionary<int, FrozenSet<int>> MouseSourceKeyboardKeysByButton { get; }
+    public bool IsEmpty => LookupMap.Count == 0;
+
+    private KeyMappingRuntimeSnapshot(
+        Dictionary<string, KeyMappingOutput> lookupMap,
+        Dictionary<int, FrozenSet<int>> mouseSourceKeyboardKeysByButton)
+    {
+        LookupMap = lookupMap.ToFrozenDictionary(StringComparer.Ordinal);
+        MouseSourceKeyboardKeysByButton = mouseSourceKeyboardKeysByButton.ToFrozenDictionary();
+    }
+
+    public static KeyMappingRuntimeSnapshot Create(IEnumerable<KeyMapping>? mappings)
+    {
+        List<KeyMapping> clonedMappings = (mappings ?? [])
+            .Select(KeyMappingMergeHelper.Clone)
+            .ToList();
+        Dictionary<string, KeyMappingOutput> lookupMap = new(StringComparer.Ordinal);
+
+        // 有效规则已按“全局后被游戏专属覆盖”的优先级排好，保留第一个匹配项。
+        foreach (KeyMapping mapping in clonedMappings)
+        {
+            if (!mapping.IsEnabled || mapping.From.Count == 0 || mapping.To.Count == 0) continue;
+            KeyMappingOutput? output = KeyMappingOutputFactory.Create(mapping.To);
+            if (output is null) continue;
+            foreach (string signature in KeyMappingMergeHelper.ExpandSourceSignatures(mapping.From))
+                lookupMap.TryAdd(signature, output);
+        }
+
+        Dictionary<int, FrozenSet<int>> mouseIndex = KeyMappingMergeHelper
+            .BuildMouseSourceKeyboardKeyIndex(clonedMappings)
+            .ToDictionary(pair => pair.Key, pair => pair.Value.ToFrozenSet());
+        return lookupMap.Count == 0
+            ? Empty
+            : new KeyMappingRuntimeSnapshot(lookupMap, mouseIndex);
+    }
+
+    /// <summary>
+    /// 根据两个独立开关生成真正应在游戏中生效的规则。
+    /// </summary>
+    public static List<KeyMapping> BuildEffectiveMappings(
+        IEnumerable<KeyMapping>? gameMappings,
+        IEnumerable<KeyMapping>? globalMappings,
+        bool gameEnabled,
+        bool globalEnabled)
+    {
+        // 保持现有开关语义：全局开关为所有游戏启用合并后的完整规则；
+        // 全局开关关闭时，KeyReMap 可单独为当前游戏启用。
+        if (!gameEnabled && !globalEnabled) return [];
+        return KeyMappingMergeHelper.BuildEffectiveMappings(gameMappings, globalMappings);
+    }
+}
+/// <summary>
+/// 热更新时暂时屏蔽仍处于按下状态的物理来源，直到用户真实释放它们。
+/// </summary>
+public sealed class KeyMappingHeldInputGuard
+{
+    private readonly HashSet<int> _keyboard = [];
+    private readonly HashSet<int> _mouse = [];
+
+    public void BeginTransition(IEnumerable<int> pressedKeyboard, IEnumerable<int> pressedMouse)
+    {
+        _keyboard.UnionWith(pressedKeyboard);
+        _mouse.UnionWith(pressedMouse);
+    }
+
+    public bool IsKeyboardSuppressed(IEnumerable<int> involvedKeys) => involvedKeys.Any(_keyboard.Contains);
+
+    public bool IsMouseSuppressed(int mouseButton, IEnumerable<int> involvedKeyboardKeys) =>
+        _mouse.Contains(mouseButton) || involvedKeyboardKeys.Any(_keyboard.Contains);
+
+    public void ReleaseKeyboard(int key) => _keyboard.Remove(key);
+
+    public void ReleaseMouse(int button) => _mouse.Remove(button);
+
+    public void Clear()
+    {
+        _keyboard.Clear();
+        _mouse.Clear();
+    }
+}

--- a/GalgameManager/Models/BgTasks/KeyMappingTask.cs
+++ b/GalgameManager/Models/BgTasks/KeyMappingTask.cs
@@ -322,17 +322,32 @@ public class KeyMappingTask : BgTaskBase
         _snapshotApplied.Reset();
         if (!PostThreadMessage(_hookThreadId, WmApplySnapshot, 0, nint.Zero))
         {
-            await Task.Run(StopHookThread);
-            Volatile.Write(ref _snapshot, nextSnapshot);
-            if (!nextSnapshot.IsEmpty)
-                await Task.Run(StartHookThread);
+            await RestartHookThreadWithSnapshotAsync(nextSnapshot, hookThread);
             return;
         }
 
         bool applied = await Task.Run(() => _snapshotApplied.Wait(TimeSpan.FromSeconds(3)));
-        if (!applied) throw new TimeoutException("应用键位映射热更新超时。");
+        if (!applied)
+        {
+            await RestartHookThreadWithSnapshotAsync(nextSnapshot, hookThread);
+            return;
+        }
         if (nextSnapshot.IsEmpty)
             await Task.Run(StopHookThread);
+    }
+
+    private async Task RestartHookThreadWithSnapshotAsync(
+        KeyMappingRuntimeSnapshot nextSnapshot,
+        Thread previousHookThread)
+    {
+        await Task.Run(StopHookThread);
+        if (previousHookThread.IsAlive)
+            throw new TimeoutException("停止无响应的按键映射钩子线程超时。");
+
+        Interlocked.Exchange(ref _pendingSnapshot, null);
+        Volatile.Write(ref _snapshot, nextSnapshot);
+        if (!nextSnapshot.IsEmpty)
+            await Task.Run(StartHookThread);
     }
 
     private void InitDirectoryPrefixes()
@@ -706,8 +721,11 @@ public class KeyMappingTask : BgTaskBase
     private void SeedPressedPhysicalMouseButtons()
     {
         for (var button = 1; button <= 5; button++)
-            if (IsKeyDown(button))
+        {
+            int virtualKey = KeyMappingMergeHelper.GetMouseButtonVirtualKey(button);
+            if (virtualKey != 0 && IsKeyDown(virtualKey))
                 _pressedPhysicalMouseButtons.Add(button);
+        }
     }
 
     private void AddPressedModifiers(ICollection<int> pressed)

--- a/GalgameManager/Models/BgTasks/KeyMappingTask.cs
+++ b/GalgameManager/Models/BgTasks/KeyMappingTask.cs
@@ -1,10 +1,12 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using CommunityToolkit.Mvvm.Messaging;
 using GalgameManager.Contracts.Services;
 using GalgameManager.Enums;
 using GalgameManager.Helpers;
 using GalgameManager.Models;
+using GalgameManager.WinApp.Base.Models.Msgs;
 using Windows.System;
 
 namespace GalgameManager.Models.BgTasks;
@@ -19,17 +21,26 @@ public class KeyMappingTask : BgTaskBase
     private Process? _process;
     private string[] _directoryPrefixes = [];
     private readonly HashSet<int> _trackedProcessIds = [];
-    private readonly Dictionary<string, KeyMappingOutput> _lookupMap = new();
-    private readonly Dictionary<int, HashSet<int>> _mouseSourceKeyboardKeysByButton = [];
+    private List<KeyMapping> _runtimeGameMappings = [];
+    private bool _runtimeGameMappingOptInEnabled;
+    private KeyMappingRuntimeSnapshot _snapshot = KeyMappingRuntimeSnapshot.Empty;
+    private KeyMappingRuntimeSnapshot? _pendingSnapshot;
     private readonly Dictionary<int, KeyMappingOutput> _activeKeyboardMappings = new();
     private readonly Dictionary<int, KeyMappingOutput> _activeMouseMappings = new();
     private readonly HashSet<int> _pressedPhysicalKeyboardKeys = [];
+    private readonly HashSet<int> _pressedPhysicalMouseButtons = [];
+    private readonly KeyMappingHeldInputGuard _heldInputGuard = new();
     private readonly KeyMappingOutputState _outputState;
+    private readonly SemaphoreSlim _reloadSemaphore = new(1, 1);
+    private ILocalSettingsService? _localSettingsService;
+    private IMessenger? _messenger;
+    private volatile bool _isMonitoring;
     private nint _keyboardHookId;
     private nint _mouseHookId;
     private Thread? _hookThread;
     private uint _hookThreadId;
     private readonly ManualResetEventSlim _hookStarted = new(false);
+    private readonly ManualResetEventSlim _snapshotApplied = new(false);
     private Exception? _hookStartException;
     private int _callbackErrorLogged;
 
@@ -108,6 +119,7 @@ public class KeyMappingTask : BgTaskBase
     private const int WmXButtonDown = 0x020B;
     private const int WmXButtonUp = 0x020C;
     private const uint WmQuit = 0x0012;
+    private const uint WmApplySnapshot = 0x8001;
     private const uint LlkhfExtended = 0x01;
     private const uint LlkhfInjected = 0x10;
     private const uint LlmhfInjected = 0x01;
@@ -151,6 +163,8 @@ public class KeyMappingTask : BgTaskBase
             Remark = m.Remark,
             IsGlobal = m.IsGlobal,
         }).ToList();
+        _runtimeGameMappings = KeyMappings.Select(KeyMappingMergeHelper.Clone).ToList();
+        _runtimeGameMappingOptInEnabled = game.KeyReMap;
         InitDirectoryPrefixes();
     }
 
@@ -166,20 +180,159 @@ public class KeyMappingTask : BgTaskBase
     {
         if (_process is null || Galgame is null) return;
 
-        BuildLookupMap();
-        if (_lookupMap.Count == 0) return;
-
+        _localSettingsService = App.GetService<ILocalSettingsService>();
+        _messenger = App.GetService<IMessenger>();
+        _runtimeGameMappings = (Galgame.KeyMappings ?? [])
+            .Select(KeyMappingMergeHelper.Clone)
+            .ToList();
+        _runtimeGameMappingOptInEnabled = Galgame.KeyReMap;
+        _isMonitoring = true;
+        _localSettingsService.OnSettingChanged += OnSettingChanged;
+        Galgame.PropertyChanged += OnGalgamePropertyChanged;
+        _messenger.Register<KeyMappingsChangedMessage>(this, (_, message) =>
+        {
+            if (Galgame?.Uuid == message.GalgameUuid)
+                message.Reply(ReloadMappingsSafelyAsync(
+                    "game mappings saved",
+                    message.GameMappings,
+                    message.GameMappingOptInEnabled,
+                    reportGameMappingsApplied: true));
+        });
         ChangeProgress(0, 1, "KeyMappingTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
         try
         {
-            await Task.Run(StartHookThread);
+            _ = await ReloadMappingsSafelyAsync("game launched");
             await FollowGameProcessAsync();
         }
         finally
         {
-            await Task.Run(StopHookThread);
+            _isMonitoring = false;
+            _localSettingsService.OnSettingChanged -= OnSettingChanged;
+            Galgame.PropertyChanged -= OnGalgamePropertyChanged;
+            _messenger.Unregister<KeyMappingsChangedMessage>(this);
+            await _reloadSemaphore.WaitAsync();
+            try
+            {
+                await Task.Run(StopHookThread);
+                Volatile.Write(ref _snapshot, KeyMappingRuntimeSnapshot.Empty);
+            }
+            finally
+            {
+                _reloadSemaphore.Release();
+            }
             ChangeProgress(1, 1, "KeyMappingTask_Done".GetLocalized());
         }
+    }
+
+    private void OnSettingChanged(string key, object? value)
+    {
+        if (key is KeyValues.GameReMapEnabled or KeyValues.GlobalKeyMappings)
+            _ = ReloadMappingsSafelyAsync($"setting changed: {key}");
+    }
+
+    private void OnGalgamePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(GalgameManager.Models.Galgame.KeyReMap))
+            _ = ReloadMappingsSafelyAsync(
+                "game mapping toggle changed",
+                updatedGameMappingOptInEnabled: Galgame?.KeyReMap);
+    }
+
+    private async Task<bool> ReloadMappingsSafelyAsync(
+        string reason,
+        IReadOnlyList<KeyMapping>? updatedGameMappings = null,
+        bool? updatedGameMappingOptInEnabled = null,
+        bool reportGameMappingsApplied = false)
+    {
+        if (!_isMonitoring || Galgame is null || _localSettingsService is null) return false;
+
+        await _reloadSemaphore.WaitAsync();
+        try
+        {
+            if (!_isMonitoring) return false;
+            if (updatedGameMappings is not null)
+                _runtimeGameMappings = updatedGameMappings
+                    .Select(KeyMappingMergeHelper.Clone)
+                    .ToList();
+            if (updatedGameMappingOptInEnabled is not null)
+                _runtimeGameMappingOptInEnabled = updatedGameMappingOptInEnabled.Value;
+
+            bool globalEnabled =
+                await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
+            bool mappingActive = _runtimeGameMappingOptInEnabled || globalEnabled;
+            List<KeyMapping> globalMappings = mappingActive
+                ? await _localSettingsService.ReadSettingAsync<List<KeyMapping>>(KeyValues.GlobalKeyMappings) ?? []
+                : [];
+            List<KeyMapping> effectiveMappings = KeyMappingRuntimeSnapshot.BuildEffectiveMappings(
+                _runtimeGameMappings,
+                globalMappings,
+                _runtimeGameMappingOptInEnabled,
+                globalEnabled);
+            KeyMappings = effectiveMappings.Select(KeyMappingMergeHelper.Clone).ToList();
+            KeyMappingRuntimeSnapshot nextSnapshot = KeyMappingRuntimeSnapshot.Create(effectiveMappings);
+
+            await ApplySnapshotAsync(nextSnapshot);
+            App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+                $"Key mappings reloaded: gameUuid={Galgame.Uuid:D}, rules={nextSnapshot.LookupMap.Count}, " +
+                $"gameOptIn={_runtimeGameMappingOptInEnabled}, globalEnabled={globalEnabled}, " +
+                $"mappingActive={mappingActive}, hookActive={!nextSnapshot.IsEmpty}, " +
+                $"mappings={DescribeSnapshot(nextSnapshot)}, reason={reason}");
+            return !reportGameMappingsApplied || mappingActive;
+        }
+        catch (Exception exception)
+        {
+            App.GetService<IInfoService>().DeveloperEvent(
+                msg: $"Failed to reload key mappings: gameUuid={Galgame?.Uuid:D}, reason={reason}",
+                e: exception);
+            return false;
+        }
+        finally
+        {
+            _reloadSemaphore.Release();
+        }
+    }
+
+    private static string DescribeSnapshot(KeyMappingRuntimeSnapshot snapshot)
+    {
+        if (snapshot.IsEmpty) return "<empty>";
+        return string.Join("; ", snapshot.LookupMap
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair =>
+            {
+                KeyMappingOutput output = pair.Value;
+                IEnumerable<int> target = output.Modifiers
+                    .Concat(output.Key is null ? [] : [output.Key.Value])
+                    .Concat(output.MouseButton is null ? [] : [output.MouseButton.Value]);
+                return $"{pair.Key}->{string.Join(',', target)}";
+            }));
+    }
+
+    private async Task ApplySnapshotAsync(KeyMappingRuntimeSnapshot nextSnapshot)
+    {
+        Thread? hookThread = _hookThread;
+        if (hookThread is null || !hookThread.IsAlive || _hookThreadId == 0)
+        {
+            Volatile.Write(ref _snapshot, nextSnapshot);
+            if (!nextSnapshot.IsEmpty)
+                await Task.Run(StartHookThread);
+            return;
+        }
+
+        Interlocked.Exchange(ref _pendingSnapshot, nextSnapshot);
+        _snapshotApplied.Reset();
+        if (!PostThreadMessage(_hookThreadId, WmApplySnapshot, 0, nint.Zero))
+        {
+            await Task.Run(StopHookThread);
+            Volatile.Write(ref _snapshot, nextSnapshot);
+            if (!nextSnapshot.IsEmpty)
+                await Task.Run(StartHookThread);
+            return;
+        }
+
+        bool applied = await Task.Run(() => _snapshotApplied.Wait(TimeSpan.FromSeconds(3)));
+        if (!applied) throw new TimeoutException("应用键位映射热更新超时。");
+        if (nextSnapshot.IsEmpty)
+            await Task.Run(StopHookThread);
     }
 
     private void InitDirectoryPrefixes()
@@ -232,27 +385,6 @@ public class KeyMappingTask : BgTaskBase
         return null;
     }
 
-    private void BuildLookupMap()
-    {
-        _lookupMap.Clear();
-        _mouseSourceKeyboardKeysByButton.Clear();
-        // Rules are already ordered by priority: global rules first, then per-game rules.
-        // TryAdd preserves the first rule when malformed or legacy data still overlaps.
-        foreach (KeyMapping mapping in KeyMappings)
-        {
-            if (!mapping.IsEnabled || mapping.From.Count == 0 || mapping.To.Count == 0) continue;
-
-            KeyMappingOutput? output = KeyMappingOutputFactory.Create(mapping.To);
-            if (output is null) continue;
-
-            foreach (string sourceSignature in KeyMappingMergeHelper.ExpandSourceSignatures(mapping.From))
-                _lookupMap.TryAdd(sourceSignature, output);
-        }
-        foreach ((int button, HashSet<int> keys) in
-                 KeyMappingMergeHelper.BuildMouseSourceKeyboardKeyIndex(KeyMappings))
-            _mouseSourceKeyboardKeysByButton[button] = keys;
-    }
-
     private void StartHookThread()
     {
         _hookStartException = null;
@@ -295,12 +427,19 @@ public class KeyMappingTask : BgTaskBase
             if (_mouseHookId == nint.Zero) throw new Win32Exception(Marshal.GetLastWin32Error());
 
             SeedPressedPhysicalKeys();
+            SeedPressedPhysicalMouseButtons();
+            _heldInputGuard.BeginTransition(_pressedPhysicalKeyboardKeys, _pressedPhysicalMouseButtons);
             _hookStarted.Set();
             while (true)
             {
                 int result = GetMessage(out NativeMessage message, nint.Zero, 0, 0);
                 if (result == 0) break;
                 if (result < 0) throw new Win32Exception(Marshal.GetLastWin32Error());
+                if (message.Message == WmApplySnapshot)
+                {
+                    ApplyPendingSnapshot();
+                    continue;
+                }
                 _ = TranslateMessage(ref message);
                 _ = DispatchMessage(ref message);
             }
@@ -341,6 +480,21 @@ public class KeyMappingTask : BgTaskBase
         if (!thread.IsAlive) _hookThread = null;
     }
 
+    private void ApplyPendingSnapshot()
+    {
+        KeyMappingRuntimeSnapshot? nextSnapshot = Interlocked.Exchange(ref _pendingSnapshot, null);
+        if (nextSnapshot is null)
+        {
+            _snapshotApplied.Set();
+            return;
+        }
+
+        ReleaseMappedOutputs();
+        _heldInputGuard.BeginTransition(_pressedPhysicalKeyboardKeys, _pressedPhysicalMouseButtons);
+        Volatile.Write(ref _snapshot, nextSnapshot);
+        _snapshotApplied.Set();
+    }
+
     private nint KeyboardHookCallback(int nCode, nint wParam, nint lParam)
     {
         if (nCode < 0) return CallNextHookEx(_keyboardHookId, nCode, wParam, lParam);
@@ -356,6 +510,7 @@ public class KeyMappingTask : BgTaskBase
             if (message is WmKeyUp or WmSysKeyUp)
             {
                 _pressedPhysicalKeyboardKeys.Remove(sourceKey);
+                _heldInputGuard.ReleaseKeyboard(sourceKey);
                 if (_activeKeyboardMappings.Remove(sourceKey, out KeyMappingOutput? active))
                 {
                     ReleaseOutput(active);
@@ -368,8 +523,12 @@ public class KeyMappingTask : BgTaskBase
 
             _pressedPhysicalKeyboardKeys.Add(sourceKey);
             if (_activeKeyboardMappings.ContainsKey(sourceKey)) return 1;
-            string keyString = BuildPressedKeyboardSourceSignature(sourceKey);
-            _lookupMap.TryGetValue(keyString, out KeyMappingOutput? output);
+            List<int> sourceKeys = BuildPressedKeyboardSourceKeys(sourceKey);
+            if (_heldInputGuard.IsKeyboardSuppressed(sourceKeys))
+                return CallNextHookEx(_keyboardHookId, nCode, wParam, lParam);
+            string keyString = KeyMappingMergeHelper.CreateSourceSignature(sourceKeys);
+            KeyMappingRuntimeSnapshot snapshot = Volatile.Read(ref _snapshot);
+            snapshot.LookupMap.TryGetValue(keyString, out KeyMappingOutput? output);
 
             bool targetForeground = IsTargetGameForeground(out _, out _);
             if (!targetForeground || output is null)
@@ -402,6 +561,8 @@ public class KeyMappingTask : BgTaskBase
 
             if (IsMouseButtonUp(message))
             {
+                _pressedPhysicalMouseButtons.Remove(mouseButton);
+                _heldInputGuard.ReleaseMouse(mouseButton);
                 if (_activeMouseMappings.Remove(mouseButton, out KeyMappingOutput? active))
                 {
                     ReleaseOutput(active);
@@ -410,9 +571,17 @@ public class KeyMappingTask : BgTaskBase
                 return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
             }
 
+            if (message != WmMouseWheel)
+                _pressedPhysicalMouseButtons.Add(mouseButton);
+
+            KeyMappingRuntimeSnapshot snapshot = Volatile.Read(ref _snapshot);
+            List<int> sourceKeyboardKeys = GetPressedMouseSourceKeyboardKeys(snapshot, mouseButton);
+            if (_heldInputGuard.IsMouseSuppressed(mouseButton, sourceKeyboardKeys))
+                return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
             bool targetForeground = IsTargetGameForeground(out _, out _);
-            string sourceSignature = BuildPressedMouseSourceSignature(mouseButton);
-            _lookupMap.TryGetValue(sourceSignature, out KeyMappingOutput? output);
+            string sourceSignature = KeyMappingMergeHelper.CreateSourceSignature(
+                sourceKeyboardKeys.Prepend(mouseButton));
+            snapshot.LookupMap.TryGetValue(sourceSignature, out KeyMappingOutput? output);
             if (!targetForeground || output is null)
                 return CallNextHookEx(_mouseHookId, nCode, wParam, lParam);
 
@@ -493,20 +662,20 @@ public class KeyMappingTask : BgTaskBase
         }
     }
 
-    private string BuildPressedKeyboardSourceSignature(int currentKey)
+    private List<int> BuildPressedKeyboardSourceKeys(int currentKey)
     {
         int normalizedCurrent = (int)NormalizeExactModifier((VirtualKey)currentKey);
         List<int> pressed = [normalizedCurrent];
         AddPressedModifiers(pressed);
-        return KeyMappingMergeHelper.CreateSourceSignature(pressed);
+        return pressed;
     }
 
-    private string BuildPressedMouseSourceSignature(int mouseButton)
+    private List<int> GetPressedMouseSourceKeyboardKeys(KeyMappingRuntimeSnapshot snapshot, int mouseButton)
     {
-        List<int> pressed = [mouseButton];
-        if (_mouseSourceKeyboardKeysByButton.TryGetValue(mouseButton, out HashSet<int>? candidates))
+        List<int> pressed = [];
+        if (snapshot.MouseSourceKeyboardKeysByButton.TryGetValue(mouseButton, out var candidates))
             pressed.AddRange(candidates.Where(IsMouseSourceCandidateDown));
-        return KeyMappingMergeHelper.CreateSourceSignature(pressed);
+        return pressed;
     }
 
     private bool IsMouseSourceCandidateDown(int key) =>
@@ -517,6 +686,7 @@ public class KeyMappingTask : BgTaskBase
 
     private void SeedPressedPhysicalKeys()
     {
+        KeyMappingRuntimeSnapshot snapshot = Volatile.Read(ref _snapshot);
         HashSet<int> candidates =
         [
             (int)VirtualKey.LeftControl,
@@ -528,9 +698,16 @@ public class KeyMappingTask : BgTaskBase
             (int)VirtualKey.LeftWindows,
             (int)VirtualKey.RightWindows,
         ];
-        candidates.UnionWith(_mouseSourceKeyboardKeysByButton.Values.SelectMany(keys => keys));
+        candidates.UnionWith(snapshot.MouseSourceKeyboardKeysByButton.Values.SelectMany(keys => keys));
         foreach (int key in candidates.Where(IsKeyDown))
             _pressedPhysicalKeyboardKeys.Add(key);
+    }
+
+    private void SeedPressedPhysicalMouseButtons()
+    {
+        for (var button = 1; button <= 5; button++)
+            if (IsKeyDown(button))
+                _pressedPhysicalMouseButtons.Add(button);
     }
 
     private void AddPressedModifiers(ICollection<int> pressed)
@@ -559,6 +736,14 @@ public class KeyMappingTask : BgTaskBase
 
     private void ReleaseAllOutputs()
     {
+        ReleaseMappedOutputs();
+        _pressedPhysicalKeyboardKeys.Clear();
+        _pressedPhysicalMouseButtons.Clear();
+        _heldInputGuard.Clear();
+    }
+
+    private void ReleaseMappedOutputs()
+    {
         try
         {
             _outputState.Reset();
@@ -569,7 +754,6 @@ public class KeyMappingTask : BgTaskBase
         }
         _activeKeyboardMappings.Clear();
         _activeMouseMappings.Clear();
-        _pressedPhysicalKeyboardKeys.Clear();
     }
 
     private static void SendMouseState(int mouseButton, bool down)
@@ -695,6 +879,7 @@ public class KeyMappingTask : BgTaskBase
         VirtualKey.RightShift => "右 Shift",
         _ => key.ToString(),
     };
+
 
     public override string Title { get; } = "KeyMappingTask_Title".GetLocalized();
 

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -147,6 +147,9 @@ public sealed class GameLaunchService(
             await _gameService.SaveGalgameAsync(game);
 
             _ = bgTaskService.AddBgTask(new RecordPlayTimeTask(game, process, installation.EntryId));
+            // 即使当前没有生效规则，也保留轻量运行时任务，
+            // 确保游戏运行期间首次启用或新增映射时可以立即生效。
+            _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process));
             await jumpListService.AddToJumpListAsync(game);
             messenger.Send(new GalgamePlayedMessage(game));
 
@@ -156,18 +159,6 @@ public sealed class GameLaunchService(
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysMuteInBackground) ||
                 game.MuteInBackground)
                 _ = bgTaskService.AddBgTask(new GameMuteTask(game, process));
-            if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled) || game.KeyReMap)
-            {
-                List<KeyMapping> globalMappings =
-                    await localSettingsService.ReadSettingAsync<List<KeyMapping>>(KeyValues.GlobalKeyMappings) ?? [];
-                List<KeyMapping> effectiveMappings =
-                    KeyMappingMergeHelper.BuildEffectiveMappings(game.KeyMappings, globalMappings);
-                if (effectiveMappings.Any(mapping =>
-                        mapping.IsEnabled && mapping.From.Count > 0 && mapping.To.Count > 0))
-                {
-                    _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process, effectiveMappings));
-                }
-            }
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AutoDetectSavePath) &&
                 config.DetectedSavePath is null)
                 _ = bgTaskService.AddBgTask(new GameSaveDetectorTask(game, installation));

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4084,4 +4084,22 @@ If play time can record correctly, just cancel this popup.
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>Wheel up</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>Wheel down</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>Mouse button {0}</value></data>
+  <data name="KeyMappingDialog_Activation_EditGlobal.Content" xml:space="preserve">
+    <value>Edit global rules</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingAppliedNow" xml:space="preserve">
+    <value>Key mappings saved and applied to the running game.</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>Key mappings saved. They will apply the next time the game starts.</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedButDisabled" xml:space="preserve">
+    <value>Key mappings saved, but both the global switch and this game's opt-in are off. Enable either switch to apply them.</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingAppliedNow" xml:space="preserve">
+    <value>Global key mappings saved and sent to running games.</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>Global key mappings saved. They will apply when a game starts.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4010,4 +4010,22 @@
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>ホイール上</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>ホイール下</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>マウスボタン {0}</value></data>
+  <data name="KeyMappingDialog_Activation_EditGlobal.Content" xml:space="preserve">
+    <value>グローバルルールを編集</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingAppliedNow" xml:space="preserve">
+    <value>キーマッピングを保存し、実行中のゲームに適用しました。</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>キーマッピングを保存しました。次回のゲーム起動時に適用されます。</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedButDisabled" xml:space="preserve">
+    <value>キーマッピングを保存しましたが、グローバル設定とこのゲームの個別有効化はどちらもオフです。いずれかを有効にすると適用されます。</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingAppliedNow" xml:space="preserve">
+    <value>グローバルキーマッピングを保存し、実行中のゲームに反映しました。</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>グローバルキーマッピングを保存しました。ゲームの次回起動時に適用されます。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -4998,4 +4998,22 @@
   <data name="KeyMapping_Mouse_WheelUp" xml:space="preserve"><value>滚轮向上</value></data>
   <data name="KeyMapping_Mouse_WheelDown" xml:space="preserve"><value>滚轮向下</value></data>
   <data name="KeyMapping_Mouse_Unknown_Format" xml:space="preserve"><value>鼠标按键 {0}</value></data>
+  <data name="KeyMappingDialog_Activation_EditGlobal.Content" xml:space="preserve">
+    <value>编辑全局规则</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingAppliedNow" xml:space="preserve">
+    <value>按键映射已保存，并已应用到正在运行的游戏。</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>按键映射已保存，将在下次启动游戏时应用。</value>
+  </data>
+  <data name="KeyMapping_Info_KeyMappingSavedButDisabled" xml:space="preserve">
+    <value>按键映射已保存，但全局开关和本游戏单独启用均已关闭；启用任一开关后即可应用。</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingAppliedNow" xml:space="preserve">
+    <value>全局按键映射已保存，并已同步到正在运行的游戏。</value>
+  </data>
+  <data name="KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch" xml:space="preserve">
+    <value>全局按键映射已保存，将在游戏下次启动时应用。</value>
+  </data>
 </root>

--- a/GalgameManager/ViewModels/GalgameSettingViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameSettingViewModel.cs
@@ -768,14 +768,20 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
             return false;
 
         await _settingsService.SaveSettingAsync(KeyValues.GlobalKeyMappings, dialog.ResultMappings);
-        bool hasRunningGames = App.GetService<IBgTaskService>()
+        KeyMappingTask[] runningTasks = App.GetService<IBgTaskService>()
             .GetBgTasks()
             .OfType<KeyMappingTask>()
-            .Any();
+            .ToArray();
+        bool globalEnabled = await IsGlobalKeyMappingEnabledAsync();
+        bool hasActiveRunningGames = runningTasks.Any(task =>
+            globalEnabled || task.Galgame?.KeyReMap == true);
+        string messageKey = hasActiveRunningGames
+            ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
+            : runningTasks.Length == 0 && globalEnabled
+                ? "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch"
+                : "KeyMapping_Info_GlobalKeyMappingSaved";
         _infoService.Info(InfoBarSeverity.Success,
-            msg: (hasRunningGames
-                ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
-                : "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch").GetLocalized(),
+            msg: messageKey.GetLocalized(),
             displayTimeMs: 3000);
         return true;
     }

--- a/GalgameManager/ViewModels/GalgameSettingViewModel.cs
+++ b/GalgameManager/ViewModels/GalgameSettingViewModel.cs
@@ -11,11 +11,13 @@ using GalgameManager.Helpers;
 using GalgameManager.Helpers.Converter;
 using GalgameManager.Helpers.EnumHelpers;
 using GalgameManager.Models;
+using GalgameManager.Models.BgTasks;
 using System.Collections.ObjectModel;
 using GalgameManager.Core.Helpers;
 using GalgameManager.Services;
 using GalgameManager.Models.Sources;
 using GalgameManager.Views.Dialog;
+using GalgameManager.WinApp.Base.Models.Msgs;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -89,6 +91,7 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
         foreach (GalgameSourceBase source in Installations.Select(i => i.Source).OfType<GalgameSourceBase>().Distinct())
             _sourceService.Save(source);
         await _galService.SaveGalgameAsync(Gal);
+        _ = await NotifyKeyMappingsChangedAsync();
         _pvnService.Upload(Gal, PvnUploadProperties.Infos | PvnUploadProperties.ImageLoc);
         Gal.PropertyChanged -= HandleGalPropertyChanged;
         _bus.Unregister<GalgameParsingEventArgs>(this);
@@ -672,7 +675,15 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
             RequestedTheme = App.MainWindow.Content is FrameworkElement element ? element.RequestedTheme : ElementTheme.Default
         };
 
-        ContentDialogResult result = await dialog.ShowAsync();
+        ContentDialogResult result;
+        while (true)
+        {
+            result = await dialog.ShowAsync();
+            if (!dialog.ConsumeGlobalMappingEditorRequest()) break;
+
+            if (await EditGlobalKeyMappingsAsync())
+                dialog.RefreshGlobalMappings(await GetGlobalKeyMappingsAsync());
+        }
 
         // 只有在用户点击保存时才保存设置并显示通知
         if (result == ContentDialogResult.Primary)
@@ -712,8 +723,16 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
             }
 
             KeyMappings = new ObservableCollection<KeyMapping>(editedMappings);
-            await SaveKeyMappingsAsync();
-            _infoService.Info(InfoBarSeverity.Success, msg:"KeyMapping_Info_KeyMappingSaved".GetLocalized(), displayTimeMs: 2000);
+            bool appliedNow = await SaveKeyMappingsAsync();
+            bool mappingEnabled = Gal.KeyReMap || await IsGlobalKeyMappingEnabledAsync();
+            string resultMessage = appliedNow
+                ? "KeyMapping_Info_KeyMappingAppliedNow"
+                : mappingEnabled
+                    ? "KeyMapping_Info_KeyMappingSavedForNextLaunch"
+                    : "KeyMapping_Info_KeyMappingSavedButDisabled";
+            _infoService.Info(InfoBarSeverity.Success,
+                msg: resultMessage.GetLocalized(),
+                displayTimeMs: 3000);
         }
     }
 
@@ -735,6 +754,32 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
         }
     }
 
+    private async Task<bool> EditGlobalKeyMappingsAsync()
+    {
+        GlobalKeyMappingDialog dialog = new(await GetGlobalKeyMappingsAsync())
+        {
+            XamlRoot = App.MainWindow!.Content.XamlRoot,
+            RequestedTheme = App.MainWindow.Content is FrameworkElement element
+                ? element.RequestedTheme
+                : ElementTheme.Default
+        };
+        ContentDialogResult result = await dialog.ShowAsync();
+        if (result is not (ContentDialogResult.Primary or ContentDialogResult.Secondary))
+            return false;
+
+        await _settingsService.SaveSettingAsync(KeyValues.GlobalKeyMappings, dialog.ResultMappings);
+        bool hasRunningGames = App.GetService<IBgTaskService>()
+            .GetBgTasks()
+            .OfType<KeyMappingTask>()
+            .Any();
+        _infoService.Info(InfoBarSeverity.Success,
+            msg: (hasRunningGames
+                ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
+                : "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch").GetLocalized(),
+            displayTimeMs: 3000);
+        return true;
+    }
+
 
     [RelayCommand]
     private void AddKeyMapping()
@@ -754,7 +799,7 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
     /// <summary>
     /// 保存当前游戏的快捷键映射设置
     /// </summary>
-    public async Task SaveKeyMappingsAsync()
+    public async Task<bool> SaveKeyMappingsAsync()
     {
         Gal.KeyMappings = KeyMappingMergeHelper.BuildPersistedGameMappings(KeyMappings);
         await _galService.SaveGalgameAsync(Gal);
@@ -763,5 +808,25 @@ public partial class GalgameSettingViewModel : ObservableObject, INavigationAwar
         List<KeyMapping> globalMappings = await GetGlobalKeyMappingsAsync();
         KeyMappings = new ObservableCollection<KeyMapping>(
             KeyMappingMergeHelper.BuildEffectiveMappings(Gal.KeyMappings, globalMappings));
+        return await NotifyKeyMappingsChangedAsync();
+    }
+
+    private async Task<bool> IsGlobalKeyMappingEnabledAsync()
+    {
+        try
+        {
+            return await _settingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
+        }
+        catch (Exception e)
+        {
+            _infoService.DeveloperEvent(e: e);
+            return false;
+        }
+    }
+
+    private async Task<bool> NotifyKeyMappingsChangedAsync()
+    {
+        KeyMappingsChangedMessage message = _bus.Send(new KeyMappingsChangedMessage(Gal));
+        return message.HasReceivedResponse && await message.Response;
     }
 }

--- a/GalgameManager/ViewModels/SettingsViewModel.cs
+++ b/GalgameManager/ViewModels/SettingsViewModel.cs
@@ -626,7 +626,12 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         if (result == ContentDialogResult.Primary || result == ContentDialogResult.Secondary)
         {
             await _localSettingsService.SaveSettingAsync(KeyValues.GlobalKeyMappings, keyMappingDialog.ResultMappings);
-            _infoService.Info(InfoBarSeverity.Success, msg: "KeyMapping_Info_GlobalKeyMappingSaved".GetLocalized(), displayTimeMs: 2000);
+            bool hasRunningGames = _bgTaskService.GetBgTasks().OfType<KeyMappingTask>().Any();
+            _infoService.Info(InfoBarSeverity.Success,
+                msg: (hasRunningGames
+                    ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
+                    : "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch").GetLocalized(),
+                displayTimeMs: 3000);
         }
     }
 

--- a/GalgameManager/ViewModels/SettingsViewModel.cs
+++ b/GalgameManager/ViewModels/SettingsViewModel.cs
@@ -626,11 +626,18 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         if (result == ContentDialogResult.Primary || result == ContentDialogResult.Secondary)
         {
             await _localSettingsService.SaveSettingAsync(KeyValues.GlobalKeyMappings, keyMappingDialog.ResultMappings);
-            bool hasRunningGames = _bgTaskService.GetBgTasks().OfType<KeyMappingTask>().Any();
+            KeyMappingTask[] runningTasks = _bgTaskService.GetBgTasks().OfType<KeyMappingTask>().ToArray();
+            bool globalEnabled =
+                await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
+            bool hasActiveRunningGames = runningTasks.Any(task =>
+                globalEnabled || task.Galgame?.KeyReMap == true);
+            string messageKey = hasActiveRunningGames
+                ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
+                : runningTasks.Length == 0 && globalEnabled
+                    ? "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch"
+                    : "KeyMapping_Info_GlobalKeyMappingSaved";
             _infoService.Info(InfoBarSeverity.Success,
-                msg: (hasRunningGames
-                    ? "KeyMapping_Info_GlobalKeyMappingAppliedNow"
-                    : "KeyMapping_Info_GlobalKeyMappingSavedForNextLaunch").GetLocalized(),
+                msg: messageKey.GetLocalized(),
                 displayTimeMs: 3000);
         }
     }

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml
@@ -33,6 +33,8 @@
                     <Button x:Name="EnableGlobalKeyMappingButton"
                             x:Uid="KeyMappingDialog_Activation_EnableGlobal"
                             Click="EnableGlobalKeyMappingButton_Click" />
+                    <Button x:Uid="KeyMappingDialog_Activation_EditGlobal"
+                            Click="EditGlobalKeyMappingButton_Click" />
                 </StackPanel>
             </InfoBar.Content>
         </InfoBar>

--- a/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/KeyMappingDialog.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class KeyMappingDialog : ContentDialog
 {
     public GalgameSettingViewModel ViewModel { get; }
     public ObservableCollection<KeyMapping> DialogKeyMappings { get; private set; } = null!;
+    public bool IsGlobalMappingEditorRequested { get; private set; }
     private readonly ObservableCollection<KeyMapping> _originalKeyMappings;
 
     public static readonly DependencyProperty HasMappingsProperty =
@@ -118,6 +119,33 @@ public sealed partial class KeyMappingDialog : ContentDialog
         bool enabled = await settings.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
         await settings.SaveSettingAsync(KeyValues.GameReMapEnabled, !enabled);
         await UpdateKeyMappingActivationStatusAsync();
+    }
+
+    private void EditGlobalKeyMappingButton_Click(object sender, RoutedEventArgs e)
+    {
+        IsGlobalMappingEditorRequested = true;
+        Hide();
+    }
+
+    public bool ConsumeGlobalMappingEditorRequest()
+    {
+        if (!IsGlobalMappingEditorRequested) return false;
+        IsGlobalMappingEditorRequested = false;
+        return true;
+    }
+
+    public void RefreshGlobalMappings(IEnumerable<KeyMapping> globalMappings)
+    {
+        List<KeyMapping> persistedGameMappings =
+            GalgameManager.Helpers.KeyMappingMergeHelper.BuildPersistedGameMappings(DialogKeyMappings);
+        List<KeyMapping> refreshedMappings =
+            GalgameManager.Helpers.KeyMappingMergeHelper.BuildEffectiveMappings(
+                persistedGameMappings, globalMappings);
+
+        DialogKeyMappings.Clear();
+        foreach (KeyMapping mapping in refreshedMappings)
+            DialogKeyMappings.Add(GalgameManager.Helpers.KeyMappingMergeHelper.Clone(mapping));
+        UpdateHasMappings();
     }
 
     private ObservableCollection<KeyMapping> CreateDeepCopy(ObservableCollection<KeyMapping> source)

--- a/GalgameManager/Views/GalgamePage.xaml
+++ b/GalgameManager/Views/GalgamePage.xaml
@@ -265,6 +265,7 @@
                     </AppBarToggleButton>
                     <!-- 快捷键映射 -->
                     <AppBarToggleButton x:Uid="GamePage_KeyReMap"
+                                        Command="{x:Bind ViewModel.SaveCommand}"
                                         IsChecked="{x:Bind ViewModel.Item.KeyReMap, Mode=TwoWay, FallbackValue=False}"
                                         IsEnabled="{x:Bind ViewModel.IsLocalGame, Mode=OneWay}">
                         <AppBarToggleButton.Icon>


### PR DESCRIPTION
这是 #714 的后续修正。目前按键映射只在游戏启动时读取一次。游戏运行期间修改规则或开关后，必须重启游戏才能生效；另外，编辑游戏规则时如果想调整全局规则，还需要退出当前页面再去设置中修改。

<img width="1264" height="760" alt="图片" src="https://github.com/user-attachments/assets/b81d4095-e47c-4b01-ad04-526f9e34e3a9" />
<img width="1264" height="760" alt="图片" src="https://github.com/user-attachments/assets/f703c3b7-544d-4e00-b6e9-fee3379add1d" />

本次修改后，保存按键映射即可应用到正在运行的游戏：

- 游戏规则、全局规则和启用状态发生变化时，运行中的映射任务会立即更新。
- 更新规则前会先释放由映射产生的键盘、鼠标和滚轮输入，避免切换规则后卡键。
- 从没有规则变为有规则时会自动启动钩子，关闭或清空规则时会停止钩子。
- 不改变现有启用逻辑：全局开关或本游戏开关任意一个开启，合并后的规则即可生效；冲突时仍以游戏规则优先。
- 游戏的按键映射窗口中增加“编辑全局规则”入口，保存后会立即刷新当前游戏继承的规则。
<img width="461" height="143" alt="图片" src="https://github.com/user-attachments/assets/3bb5ee2d-509a-4dc8-92bc-c1086690d3b9" />

## 测试

- 按键映射相关单元测试与三种语言资源检查通过。
- 在本地测试版中修改游戏规则和全局规则，保存后均能立即生效。
- 从游戏页面进入全局规则编辑器，保存后当前游戏继承的规则会正常刷新。