### PR TITLE
fix: 修复自动导出只在启动时检查的问题

### DIFF
--- a/GalgameManager.Test/ServiceTestBase.cs
+++ b/GalgameManager.Test/ServiceTestBase.cs
@@ -111,11 +111,9 @@ public class FakeLocalSettingsService : ILocalSettingsService
         TemporaryFolder = new DirectoryInfo(Path.Combine(rootDir, "Temp"));
     }
 
-    public event ILocalSettingsService.Delegate? OnSettingChanged
-    {
-        add { }
-        remove { }
-    }
+    public event ILocalSettingsService.Delegate? OnSettingChanged;
+
+    public void RaiseSettingChanged(string key, object? value) => OnSettingChanged?.Invoke(key, value);
 
     public DirectoryInfo LocalFolder { get; }
 
@@ -176,8 +174,6 @@ public class FakeLocalSettingsService : ILocalSettingsService
     public Task<StorageFolder> GetTmpExportFolder() => throw new NotImplementedException();
 
     public Task<string> BackupFailedDataAsync(bool removeAfterBackup = true) => throw new NotImplementedException();
-
-    public Task StartupAsync() => Task.CompletedTask;
 
     public Task ImportPageSettingsAsync() => Task.CompletedTask;
 

--- a/GalgameManager.Test/Services/AutoExportServiceTest.cs
+++ b/GalgameManager.Test/Services/AutoExportServiceTest.cs
@@ -1,0 +1,243 @@
+using GalgameManager.Contracts.Services;
+using GalgameManager.Enums;
+using GalgameManager.Models.BgTasks;
+using GalgameManager.Services;
+using Moq;
+
+namespace GalgameManager.Test.Services;
+
+[TestFixture]
+public class AutoExportServiceTest : ServiceTestBase
+{
+    private static readonly DateTime Now = new(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+    private FixedTimeProvider _timeProvider = null!;
+
+    [SetUp]
+    public void AutoExportServiceTestSetUp()
+    {
+        _timeProvider = new FixedTimeProvider(Now);
+    }
+
+    // 验证关闭开关会真实写入设置，而不是只改变当前页面上的显示状态
+    [Test]
+    public async Task SetEnabledAsync_Disable_PersistsFalse()
+    {
+        await Settings.SaveSettingAsync(KeyValues.AutoExport, true);
+        TestAutoExportService service = CreateService();
+
+        bool result = await service.SetEnabledAsync(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(Settings.ReadSettingAsync<bool>(KeyValues.AutoExport).Result, Is.False);
+        });
+    }
+
+    // 验证导出路径无效时不能启用自动导出，并清除之前残留的启用状态
+    [Test]
+    public async Task SetEnabledAsync_InvalidPath_PersistsFalse()
+    {
+        await Settings.SaveSettingAsync(KeyValues.AutoExport, true);
+        await Settings.SaveSettingAsync(KeyValues.AutoExportPath, Path.Combine(TestDir, "不存在"));
+        TestAutoExportService service = CreateService();
+
+        bool result = await service.SetEnabledAsync(true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(Settings.ReadSettingAsync<bool>(KeyValues.AutoExport).Result, Is.False);
+        });
+    }
+
+    // 验证应用启动后会立即检查一次；到达间隔时无需再次启动应用即可导出
+    [Test]
+    public async Task Start_ExportIsDue_EnqueuesImmediately()
+    {
+        string exportPath = await ConfigureAsync(enabled: true, lastExportTime: Now.AddHours(-2));
+        var addedCount = 0;
+        BgTaskService.Setup(x => x.AddBgTask(It.IsAny<BgTaskBase>()))
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref addedCount);
+                await Settings.SaveSettingAsync(KeyValues.LastExportTime, Now);
+            });
+        TestAutoExportService service = CreateService();
+
+        service.Start();
+        service.Start();
+        await WaitUntilAsync(() => Volatile.Read(ref addedCount) == 1, "等待自动导出任务入队超时");
+        service.Stop();
+
+        Assert.That(service.CreatedPaths, Is.EqualTo(new[] { exportPath }));
+    }
+
+    // 验证未到间隔时启动调度不会提前导出
+    [Test]
+    public async Task Start_ExportIsNotDue_DoesNotEnqueue()
+    {
+        await ConfigureAsync(enabled: true, lastExportTime: Now.AddMinutes(-30));
+        TestAutoExportService service = CreateService();
+
+        service.Start();
+        await Task.Delay(200);
+        service.Stop();
+
+        BgTaskService.Verify(x => x.AddBgTask(It.IsAny<BgTaskBase>()), Times.Never);
+    }
+
+    // 验证软件运行期间开启自动导出会唤醒调度，不需要重启应用
+    [Test]
+    public async Task SettingChanged_EnableWhileRunning_EnqueuesWithoutRestart()
+    {
+        await ConfigureAsync(enabled: false, lastExportTime: Now.AddHours(-2));
+        var addedCount = 0;
+        BgTaskService.Setup(x => x.AddBgTask(It.IsAny<BgTaskBase>()))
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref addedCount);
+                await Settings.SaveSettingAsync(KeyValues.LastExportTime, Now);
+            });
+        TestAutoExportService service = CreateService();
+        service.Start();
+        await Task.Delay(100);
+
+        await Settings.SaveSettingAsync(KeyValues.AutoExport, true);
+        Settings.RaiseSettingChanged(KeyValues.AutoExport, true);
+
+        await WaitUntilAsync(() => Volatile.Read(ref addedCount) == 1, "运行中开启后未触发自动导出");
+        service.Stop();
+    }
+
+    // 验证自动与手动导出共用同一把锁，不会同时创建两个导出任务
+    [Test]
+    public async Task ExportAsync_ConcurrentCalls_OnlyStartsOneTask()
+    {
+        string exportPath = CreateDir("Export");
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var addedCount = 0;
+        BgTaskService.Setup(x => x.AddBgTask(It.IsAny<BgTaskBase>()))
+            .Returns(() =>
+            {
+                Interlocked.Increment(ref addedCount);
+                return gate.Task;
+            });
+        TestAutoExportService service = CreateService();
+
+        Task<bool> firstExport = service.ExportAsync(exportPath);
+        await WaitUntilAsync(() => Volatile.Read(ref addedCount) == 1, "第一个导出任务未入队");
+        bool secondResult = await service.ExportAsync(exportPath);
+        gate.SetResult();
+        bool firstResult = await firstExport;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstResult, Is.True);
+            Assert.That(secondResult, Is.False);
+            Assert.That(addedCount, Is.EqualTo(1));
+        });
+    }
+
+    // 验证自动导出失败后进入冷却时间，设置事件不会造成连续重试和通知刷屏
+    [Test]
+    public async Task Start_ExportFails_DoesNotRetryBeforeCooldown()
+    {
+        await ConfigureAsync(enabled: true, lastExportTime: Now.AddHours(-2));
+        var addedCount = 0;
+        BgTaskService.Setup(x => x.AddBgTask(It.IsAny<BgTaskBase>()))
+            .Returns(() =>
+            {
+                Interlocked.Increment(ref addedCount);
+                return Task.CompletedTask;
+            });
+        TestAutoExportService service = CreateService();
+
+        service.Start();
+        await WaitUntilAsync(() => Volatile.Read(ref addedCount) == 1, "第一次自动导出未触发");
+        Settings.RaiseSettingChanged(KeyValues.AutoExportInterval, 1d);
+        await Task.Delay(200);
+        service.Stop();
+
+        Assert.That(addedCount, Is.EqualTo(1));
+    }
+
+    // 验证达到备份数量上限时，会在新导出开始前删除最旧的文件并保留较新的备份
+    [Test]
+    public async Task Start_BackupLimitReached_PrunesOldestFiles()
+    {
+        string exportPath = await ConfigureAsync(enabled: true, lastExportTime: Now.AddHours(-2));
+        await Settings.SaveSettingAsync(KeyValues.MaxBackupNumber, 2);
+        string oldest = Path.Combine(exportPath, "PotatoVN_oldest.pvnExport.zip");
+        string middle = Path.Combine(exportPath, "PotatoVN_middle.pvnExport.zip");
+        string newest = Path.Combine(exportPath, "PotatoVN_newest.pvnExport.zip");
+        await File.WriteAllTextAsync(oldest, "oldest");
+        await File.WriteAllTextAsync(middle, "middle");
+        await File.WriteAllTextAsync(newest, "newest");
+        File.SetCreationTimeUtc(oldest, Now.AddDays(-3));
+        File.SetCreationTimeUtc(middle, Now.AddDays(-2));
+        File.SetCreationTimeUtc(newest, Now.AddDays(-1));
+        var addedCount = 0;
+        BgTaskService.Setup(x => x.AddBgTask(It.IsAny<BgTaskBase>()))
+            .Returns(async () =>
+            {
+                Interlocked.Increment(ref addedCount);
+                await Settings.SaveSettingAsync(KeyValues.LastExportTime, Now);
+            });
+        TestAutoExportService service = CreateService();
+
+        service.Start();
+        await WaitUntilAsync(() => Volatile.Read(ref addedCount) == 1, "等待滚动备份后的导出任务入队超时");
+        service.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(File.Exists(oldest), Is.False);
+            Assert.That(File.Exists(middle), Is.False);
+            Assert.That(File.Exists(newest), Is.True);
+        });
+    }
+
+    private TestAutoExportService CreateService() =>
+        new(Settings, BgTaskService.Object, InfoService.Object, _timeProvider);
+
+    private async Task<string> ConfigureAsync(bool enabled, DateTime lastExportTime)
+    {
+        string exportPath = CreateDir("Export");
+        await Settings.SaveSettingAsync(KeyValues.AutoExport, enabled);
+        await Settings.SaveSettingAsync(KeyValues.AutoExportPath, exportPath);
+        await Settings.SaveSettingAsync(KeyValues.AutoExportInterval, 1d);
+        await Settings.SaveSettingAsync(KeyValues.LastExportTime, lastExportTime);
+        await Settings.SaveSettingAsync(KeyValues.MaxBackupNumber, 5);
+        return exportPath;
+    }
+
+    private sealed class TestAutoExportService(ILocalSettingsService localSettingsService,
+        IBgTaskService bgTaskService, IInfoService infoService, TimeProvider timeProvider)
+        : AutoExportService(localSettingsService, bgTaskService, infoService, timeProvider)
+    {
+        public List<string> CreatedPaths { get; } = [];
+
+        protected override BgTaskBase CreateExportTask(string targetPath)
+        {
+            CreatedPaths.Add(targetPath);
+            return new TestExportTask();
+        }
+    }
+
+    private sealed class TestExportTask : BgTaskBase
+    {
+        public override string Title => "测试导出任务";
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override Task RunInternal() => Task.CompletedTask;
+    }
+
+    private sealed class FixedTimeProvider(DateTime now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new(now);
+
+        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+    }
+}

--- a/GalgameManager/App.xaml.cs
+++ b/GalgameManager/App.xaml.cs
@@ -90,6 +90,8 @@ public partial class App : Application
             services.AddTransient<INavigationViewService, NavigationViewService>();
             services.AddSingleton<IThemeSelectorService, ThemeSelectorService>();
             services.AddSingleton<ILocalSettingsService, LocalSettingsService>();
+            services.AddSingleton<IAutoExportService, AutoExportService>();
+            services.AddSingleton(TimeProvider.System);
             services.AddTransient<IJumpListService, JumpListService>();
             services.AddSingleton<IActivationService, ActivationService>();
             services.AddSingleton<IPageService, PageService>();
@@ -249,6 +251,7 @@ public partial class App : Application
                 MainWindow!.Minimize();
                 break;
             case WindowMode.SystemTray:
+                GetService<IAutoExportService>().Stop();
                 OnAppClosing?.Invoke();
                 GetService<IBgTaskService>().SaveBgTasksString();
                 MainWindow?.Close();
@@ -257,6 +260,7 @@ public partial class App : Application
                 break;
             case WindowMode.Close:
                 Status = WindowMode.Close;
+                GetService<IAutoExportService>().Stop();
                 OnAppClosing?.Invoke();
                 SystemTray?.Dispose();
                 _instance.Exit();

--- a/GalgameManager/Contracts/Services/IAutoExportService.cs
+++ b/GalgameManager/Contracts/Services/IAutoExportService.cs
@@ -1,0 +1,25 @@
+namespace GalgameManager.Contracts.Services;
+
+public interface IAutoExportService
+{
+    /// <summary>
+    /// 启动自动导出调度。重复调用不会创建多个调度循环。
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// 停止自动导出调度，不会中断已经开始的导出任务。
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    /// 保存自动导出开关；启用时会先验证导出路径。
+    /// </summary>
+    /// <returns>设置是否成功生效。</returns>
+    Task<bool> SetEnabledAsync(bool enabled);
+
+    /// <summary>
+    /// 启动一次手动导出；已有导出任务运行时返回 false。
+    /// </summary>
+    Task<bool> ExportAsync(string targetPath);
+}

--- a/GalgameManager/Contracts/Services/ILocalSettingsService.cs
+++ b/GalgameManager/Contracts/Services/ILocalSettingsService.cs
@@ -97,11 +97,6 @@ public interface ILocalSettingsService
     Task<string> BackupFailedDataAsync(bool removeAfterBackup = true);
 
     /// <summary>
-    /// App启动时调用
-    /// </summary>
-    public Task StartupAsync();
-
-    /// <summary>
     /// 若当前数据来自导入（<see cref="Models.LocalSettingStatus.ImportPageSettings"/> 为 false），
     /// 把导出包中携带的游戏列表页/库页设置（排序等）写回本机设置，随后标记为已处理。<br/>
     /// 应在导入解压完成、页面读取设置之前调用，且仅生效一次。

--- a/GalgameManager/Services/ActivationService.cs
+++ b/GalgameManager/Services/ActivationService.cs
@@ -35,6 +35,7 @@ public class ActivationService : IActivationService
     private readonly IPvnService _pvnService;
     private readonly IPluginService _pluginService;
     private readonly IInfoService _infoService;
+    private readonly IAutoExportService _autoExportService;
 
     public ActivationService(
         IEnumerable<IActivationHandler> activationHandlers, IThemeSelectorService themeSelectorService,
@@ -44,7 +45,8 @@ public class ActivationService : IActivationService
         ICategoryService categoryService,IBgmOAuthService bgmOAuthService,
         IAuthenticationService authenticationService, ILocalSettingsService localSettingsService,
         IFilterService filterService, IPageService pageService, IBgTaskService bgTaskService, IPvnService pvnService,
-        IInfoService infoService, IStaffService staffService, IPluginService pluginService, ISidebarService sidebarService)
+        IInfoService infoService, IStaffService staffService, IPluginService pluginService,
+        ISidebarService sidebarService, IAutoExportService autoExportService)
     {
         _activationHandlers = activationHandlers;
         _themeSelectorService = themeSelectorService;
@@ -64,6 +66,7 @@ public class ActivationService : IActivationService
         _staffService = staffService;
         _pluginService = pluginService;
         _sidebarService = sidebarService;
+        _autoExportService = autoExportService;
     }
 
     public async Task LaunchedAsync(object activationArgs)
@@ -213,10 +216,10 @@ public class ActivationService : IActivationService
             activateWindow = !await _localSettingsService.ReadSettingAsync<bool>(KeyValues.MinToTrayWhenAutoStart);
         if (activateWindow) App.SetWindowMode(WindowMode.Normal);
         await _pluginService.InitAsync();
+        if (!isUpgradeUiTest) _autoExportService.Start();
         if (IsRestart() == false && !isUpgradeUiTest)
         {
             _pvnService.Startup();
-            await _localSettingsService.StartupAsync();
             await _updateService.UpdateSettingsBadgeAsync();
         }
         if (!isUpgradeUiTest)

--- a/GalgameManager/Services/AutoExportService.cs
+++ b/GalgameManager/Services/AutoExportService.cs
@@ -1,0 +1,207 @@
+using GalgameManager.Contracts.Services;
+using GalgameManager.Enums;
+using GalgameManager.Models.BgTasks;
+
+namespace GalgameManager.Services;
+
+public class AutoExportService : IAutoExportService
+{
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan FailureRetryInterval = TimeSpan.FromMinutes(5);
+    private static readonly HashSet<string> RelevantSettingKeys =
+    [
+        KeyValues.AutoExport,
+        KeyValues.AutoExportInterval,
+        KeyValues.AutoExportPath,
+        KeyValues.LastExportTime,
+        KeyValues.MaxBackupNumber,
+    ];
+
+    private readonly ILocalSettingsService _localSettingsService;
+    private readonly IBgTaskService _bgTaskService;
+    private readonly IInfoService _infoService;
+    private readonly TimeProvider _timeProvider;
+    private readonly SemaphoreSlim _wakeSignal = new(0, 1);
+    private readonly SemaphoreSlim _exportLock = new(1, 1);
+    private readonly object _lifecycleLock = new();
+    private CancellationTokenSource? _cancellationTokenSource;
+    private Task? _runTask;
+    private DateTime _retryNotBefore = DateTime.MinValue;
+
+    public AutoExportService(ILocalSettingsService localSettingsService, IBgTaskService bgTaskService,
+        IInfoService infoService, TimeProvider timeProvider)
+    {
+        _localSettingsService = localSettingsService;
+        _bgTaskService = bgTaskService;
+        _infoService = infoService;
+        _timeProvider = timeProvider;
+        _localSettingsService.OnSettingChanged += OnSettingChanged;
+    }
+
+    public void Start()
+    {
+        lock (_lifecycleLock)
+        {
+            if (_runTask is { IsCompleted: false }) return;
+            _cancellationTokenSource = new CancellationTokenSource();
+            _runTask = RunAsync(_cancellationTokenSource.Token);
+        }
+    }
+
+    public void Stop()
+    {
+        lock (_lifecycleLock)
+        {
+            _cancellationTokenSource?.Cancel();
+        }
+        WakeUp();
+    }
+
+    public async Task<bool> SetEnabledAsync(bool enabled)
+    {
+        if (enabled)
+        {
+            string? path = await _localSettingsService.ReadSettingAsync<string>(KeyValues.AutoExportPath);
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+            {
+                await _localSettingsService.SaveSettingAsync(KeyValues.AutoExport, false);
+                return false;
+            }
+        }
+
+        await _localSettingsService.SaveSettingAsync(KeyValues.AutoExport, enabled);
+        return true;
+    }
+
+    public Task<bool> ExportAsync(string targetPath) =>
+        ExportInternalAsync(targetPath, pruneOldBackups: false, CancellationToken.None);
+
+    protected virtual BgTaskBase CreateExportTask(string targetPath) => new ExportTask(targetPath);
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await CheckAndExportAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                _retryNotBefore = Now.Add(FailureRetryInterval);
+                _infoService.DeveloperEvent(e: e);
+            }
+
+            try
+            {
+                await WaitForNextCheckAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+        }
+    }
+
+    private async Task CheckAndExportAsync(CancellationToken cancellationToken)
+    {
+        if (!await _localSettingsService.ReadSettingAsync<bool>(KeyValues.AutoExport))
+        {
+            _retryNotBefore = DateTime.MinValue;
+            return;
+        }
+
+        DateTime now = Now;
+        if (now < _retryNotBefore) return;
+
+        DateTime lastExportTime = await _localSettingsService.ReadSettingAsync<DateTime>(KeyValues.LastExportTime);
+        double intervalHours = await _localSettingsService.ReadSettingAsync<double>(KeyValues.AutoExportInterval);
+        TimeSpan interval = double.IsFinite(intervalHours) && intervalHours > 0
+            ? TimeSpan.FromHours(intervalHours)
+            : TimeSpan.FromHours(1);
+        if (now < lastExportTime.Add(interval)) return;
+
+        string? path = await _localSettingsService.ReadSettingAsync<string>(KeyValues.AutoExportPath);
+        if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) return;
+
+        bool started = await ExportInternalAsync(path, pruneOldBackups: true, cancellationToken);
+        if (!started) return;
+
+        DateTime updatedExportTime = await _localSettingsService.ReadSettingAsync<DateTime>(KeyValues.LastExportTime);
+        _retryNotBefore = updatedExportTime > lastExportTime
+            ? DateTime.MinValue
+            : now.Add(FailureRetryInterval);
+    }
+
+    private async Task<bool> ExportInternalAsync(string targetPath, bool pruneOldBackups,
+        CancellationToken cancellationToken)
+    {
+        if (!await _exportLock.WaitAsync(0, cancellationToken)) return false;
+        try
+        {
+            if (_bgTaskService.GetBgTask<ExportTask>(string.Empty) is not null) return false;
+            if (pruneOldBackups) await PruneOldBackupsAsync(targetPath);
+            await _bgTaskService.AddBgTask(CreateExportTask(targetPath));
+            return true;
+        }
+        finally
+        {
+            _exportLock.Release();
+        }
+    }
+
+    private async Task PruneOldBackupsAsync(string path)
+    {
+        int maxBackupNumber = await _localSettingsService.ReadSettingAsync<int?>(KeyValues.MaxBackupNumber) ?? 999;
+        maxBackupNumber = Math.Max(maxBackupNumber, 1);
+        List<string> files = Directory.GetFiles(path, "*.pvnExport.zip")
+            .OrderBy(File.GetCreationTime)
+            .ToList();
+        int deleteCount = files.Count - maxBackupNumber + 1;
+        for (var i = 0; i < deleteCount; i++)
+        {
+            try
+            {
+                File.Delete(files[i]);
+            }
+            catch (Exception e)
+            {
+                _infoService.DeveloperEvent(e: e);
+            }
+        }
+    }
+
+    private async Task WaitForNextCheckAsync(CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource waitCancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task delayTask = Task.Delay(CheckInterval, _timeProvider, waitCancellationTokenSource.Token);
+        Task signalTask = _wakeSignal.WaitAsync(waitCancellationTokenSource.Token);
+        Task completedTask = await Task.WhenAny(delayTask, signalTask);
+        await waitCancellationTokenSource.CancelAsync();
+        await completedTask;
+    }
+
+    private void OnSettingChanged(string key, object? value)
+    {
+        if (RelevantSettingKeys.Contains(key)) WakeUp();
+    }
+
+    private void WakeUp()
+    {
+        try
+        {
+            _wakeSignal.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // 已有一个待处理的唤醒信号时无需重复排队。
+        }
+    }
+
+    private DateTime Now => _timeProvider.GetLocalNow().DateTime;
+}

--- a/GalgameManager/Services/LocalSettingsService.cs
+++ b/GalgameManager/Services/LocalSettingsService.cs
@@ -536,52 +536,6 @@ public class LocalSettingsService : ILocalSettingsService
         return failedFolder.FullName;
     }
 
-    public async Task StartupAsync()
-    {
-        try
-        {
-            if (await ReadSettingAsync<bool>(KeyValues.AutoExport))
-            {
-                DateTime lastExportTime = await ReadSettingAsync<DateTime>(KeyValues.LastExportTime);
-                var interval = await ReadSettingAsync<double>(KeyValues.AutoExportInterval);
-                if ((DateTime.Now - lastExportTime).TotalHours > interval)
-                {
-                    var path = await ReadSettingAsync<string>(KeyValues.AutoExportPath);
-                    if (string.IsNullOrEmpty(path) || !Directory.Exists(path)) return;
-
-                    // 滚动备份
-                    var maxBackupNumber = await ReadSettingAsync<int?>(KeyValues.MaxBackupNumber) ?? 999;
-                    List<string> files = Directory.GetFiles(path, "*.pvnExport.zip").ToList();
-                    if (files.Count >= maxBackupNumber)
-                    {
-                        files.Sort((x, y) =>
-                            File.GetCreationTime(x).CompareTo(File.GetCreationTime(y)));
-                        for (var i = 0; i <= files.Count - maxBackupNumber; i++)
-                        {
-                            try
-                            {
-                                File.Delete(files[i]);
-                            }
-                            catch (Exception e)
-                            {
-                                App.GetService<IInfoService>().DeveloperEvent(e: e);
-                            }
-                        }
-                    }
-
-                    IBgTaskService bgTaskService = App.GetService<IBgTaskService>();
-                    if (bgTaskService.GetBgTask<Models.BgTasks.ExportTask>(string.Empty) is not null) return;
-                    await bgTaskService.AddBgTask(new Models.BgTasks.ExportTask(path));
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            App.GetService<IInfoService>().DeveloperEvent(e: e);
-        }
-
-    }
-
     public async Task ImportPageSettingsAsync()
     {
         try

--- a/GalgameManager/ViewModels/SettingsViewModel.cs
+++ b/GalgameManager/ViewModels/SettingsViewModel.cs
@@ -42,7 +42,9 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     private readonly IInfoService _infoService;
     private readonly IBgTaskService _bgTaskService;
     private readonly ISidebarService _sidebarService;
+    private readonly IAutoExportService _autoExportService;
     private string _versionDescription;
+    private bool _isCorrectingAutoExportToggle;
 
     #region UI_STRINGS //历史遗留，不要继续使用这种方式获取字符串
 
@@ -85,6 +87,11 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     public async void OnNavigatedTo(object parameter)
     {
+        _localSettingsService.OnSettingChanged -= HandleAutoExportSettingChanged;
+        _localSettingsService.OnSettingChanged += HandleAutoExportSettingChanged;
+        _lastExportTime = await _localSettingsService.ReadSettingAsync<DateTime>(KeyValues.LastExportTime);
+        UpdateAutoExportDescriptions();
+
         // 设置页会被 Frame 缓存；外部入口（例如单游戏按键映射对话框）修改总开关后，
         // 每次返回设置页都重新读取，避免界面状态与真实启动配置不一致。
         GameReMapEnabled = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
@@ -101,6 +108,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     public void OnNavigatedFrom()
     {
+        _localSettingsService.OnSettingChanged -= HandleAutoExportSettingChanged;
         _updateService.SettingBadgeEvent -= HandelSettingBadgeEvent;
         _galgameCollectionService.MetaSavedEvent -= SetSaveMetaPopUp;
     }
@@ -108,7 +116,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     public SettingsViewModel(IThemeSelectorService themeSelectorService, ILocalSettingsService localSettingsService,
         IGalgameCollectionService galgameService, IUpdateService updateService, INavigationService navigationService,
         ICategoryService categoryService, IInfoService infoService, IBgTaskService bgTaskService,
-        ISidebarService sidebarService)
+        ISidebarService sidebarService, IAutoExportService autoExportService)
     {
         _categoryService = categoryService;
         _themeSelectorService = themeSelectorService;
@@ -120,6 +128,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         _infoService = infoService;
         _bgTaskService = bgTaskService;
         _sidebarService = sidebarService;
+        _autoExportService = autoExportService;
 
         //THEME
         _elementTheme = themeSelectorService.Theme;
@@ -1159,17 +1168,18 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
     async partial void OnIsAutoExportEnabledChanged(bool value)
     {
+        if (_isCorrectingAutoExportToggle) return;
         try
         {
-            if (!value) return;
-            if (IsNullOrEmpty(_autoExportPath) || !Directory.Exists(_autoExportPath))
+            if (!await _autoExportService.SetEnabledAsync(value))
             {
-                _infoService.Info(InfoBarSeverity.Error, msg: "SettingsPage_Other_AutoExport_PathInvalid".GetLocalized());
+                _isCorrectingAutoExportToggle = true;
                 IsAutoExportEnabled = false;
+                _isCorrectingAutoExportToggle = false;
+                _infoService.Info(InfoBarSeverity.Error, msg: "SettingsPage_Other_AutoExport_PathInvalid".GetLocalized());
                 return;
             }
-            await _localSettingsService.SaveSettingAsync(KeyValues.AutoExport, value);
-            _infoService.Info(InfoBarSeverity.Success, msg: "SettingSuccess".GetLocalized() + ", " + "RestartRequired".GetLocalized());
+            _infoService.Info(InfoBarSeverity.Success, msg: "SettingSuccess".GetLocalized());
         }
         catch (Exception e)
         {
@@ -1191,6 +1201,13 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         AutoExportPathDescription = IsNullOrEmpty(_autoExportPath)
             ? "SettingsPage_Other_AutoExport_Path_NotSet".GetLocalized()
             : "SettingsPage_Other_AutoExport_Path_Description".GetLocalized(_autoExportPath);
+    }
+
+    private void HandleAutoExportSettingChanged(string key, object? value)
+    {
+        if (key != KeyValues.LastExportTime || value is not DateTime lastExportTime) return;
+        _lastExportTime = lastExportTime;
+        UpdateAutoExportDescriptions();
     }
 
     [RelayCommand]
@@ -1229,8 +1246,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
             var path = folder?.Path;
             if (path is null) return;
 
-            ExportTask task = new(path);
-            await _bgTaskService.AddBgTask(task);
+            if (!await _autoExportService.ExportAsync(path))
+                _infoService.Info(InfoBarSeverity.Warning, "SettingsPage_Other_Export_Exporting".GetLocalized());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
自动导出目前只会在应用正常启动时检查一次。应用持续运行超过设置间隔，或者通过内部重启进入托盘模式后，都不会再次检查，因此实际导出时间取决于用户下次什么时候重新打开应用。

另外有个小bug，设置页关闭自动导出时会在保存前直接返回：界面上的开关虽然关闭了，保存的设置仍然是开启状态，重启应用后开关还会再次打开。

这次把自动导出调度从 `LocalSettingsService` 中分离到了独立服务：

- 应用启动及托盘模式内部重启后都会启动调度，启动时立即检查一次，之后每分钟检查一次是否到期。
- 修改开关、间隔、导出路径、备份数量或上次导出时间后会立即重新检查，不再要求重启应用。
- 开启和关闭状态都会写入设置；启用时如果导出路径无效，会保存为关闭状态并保持界面一致。
- 自动或手动导出完成后，设置页会立即刷新“上次导出时间”；离开设置页后再返回也会重新读取最新值。
- 手动导出和自动导出共用并发保护，避免两次导出同时运行。
- 自动导出失败后等待五分钟再重试，避免连续产生失败通知；原有的滚动备份数量限制保持不变。

手动导出成功后仍会更新 `LastExportTime`，因此会从这次成功导出开始重新计算下一次自动导出时间。

## 与 #717 的关系

之前在等 #717合并，运行期调度允许同一天自动导出多次，因此沿用 #717 提供的秒级文件名来避免重名冲突。

## 验证

新增 8 项单元测试，覆盖开关持久化、无效路径回退、到期判断、运行中启用、防止调度器重复启动、手动与自动导出互斥、失败冷却及滚动备份清理，8/8 通过。独立分支的三向功能差异检查通过，x64 Release 构建正常；关闭开关后的重启持久化也已实机验证。