### PR TITLE
fix: 跟踪启动器接力后的实际游戏进程

### DIFF
--- a/GalgameManager.Test/Helpers/GameProcessDetectorTest.cs
+++ b/GalgameManager.Test/Helpers/GameProcessDetectorTest.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameProcessDetectorTest
+{
+    [Test]
+    public void IsProcessIdPresent_FindsCurrentProcessWithoutQueryingTargetState()
+    {
+        using Process current = Process.GetCurrentProcess();
+
+        Assert.That(GameProcessDetector.IsProcessIdPresent(current.Id), Is.True);
+    }
+
+    [Test]
+    public void IsProcessIdPresent_RejectsInvalidIds()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameProcessDetector.IsProcessIdPresent(0), Is.False);
+            Assert.That(GameProcessDetector.IsProcessIdPresent(-1), Is.False);
+        });
+    }
+
+    [Test]
+    public void WaitForExitSafelyAsync_StillHonorsCancellationForRunningProcess()
+    {
+        using Process current = Process.GetCurrentProcess();
+        using CancellationTokenSource cancellation = new(TimeSpan.FromMilliseconds(100));
+
+        Assert.That(async () => await GameProcessDetector.WaitForExitSafelyAsync(current, cancellation.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+}

--- a/GalgameManager.Test/Helpers/GameRuntimeProcessRelayTest.cs
+++ b/GalgameManager.Test/Helpers/GameRuntimeProcessRelayTest.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameRuntimeProcessRelayTest
+{
+    [Test]
+    public async Task Confirm_PublishesConfirmedProcess()
+    {
+        GameRuntimeProcessRelay relay = new();
+        using Process process = Process.GetCurrentProcess();
+
+        relay.Confirm(process);
+        Process? confirmed = await relay.WaitForConfirmationAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(confirmed, Is.SameAs(process));
+            Assert.That(relay.ConfirmedProcess, Is.SameAs(process));
+            Assert.That(relay.IsCompleted, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task CompleteWithoutConfirmation_ReleasesWaiterWithNull()
+    {
+        GameRuntimeProcessRelay relay = new();
+        Task<Process?> waiter = relay.WaitForConfirmationAsync();
+
+        relay.Complete();
+        Process? result = await waiter;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Null);
+            Assert.That(relay.IsCompleted, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ConfirmAfterCompletion_DoesNotPublishProcess()
+    {
+        GameRuntimeProcessRelay relay = new();
+        using Process process = Process.GetCurrentProcess();
+        relay.Complete();
+
+        relay.Confirm(process);
+
+        Assert.That(await relay.WaitForConfirmationAsync(), Is.Null);
+        Assert.That(relay.ConfirmedProcess, Is.Null);
+    }
+}

--- a/GalgameManager.Test/Helpers/GameWindowTransitionGateTest.cs
+++ b/GalgameManager.Test/Helpers/GameWindowTransitionGateTest.cs
@@ -1,0 +1,314 @@
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameWindowTransitionGateTest
+{
+    [Test]
+    public void Observe_UnchangedLaunchDialog_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+            Assert.That(gate.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+        });
+    }
+
+    [Test]
+    public void Observe_LaunchDialogLayoutChanges_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot opening = Snapshot(100, 10, "Dialog", "", 360, 240);
+        GameWindowSnapshot ready = Snapshot(100, 10, "Dialog", "Disclaimer", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(opening), Is.False);
+            Assert.That(gate.Observe(ready), Is.False);
+            Assert.That(gate.Observe(ready), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+        });
+    }
+
+    [Test]
+    public void Observe_FirstWindowBelongsToReplacementProcess_RemainsPendingUntilWindowChanges()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot replacementDialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "TVPMainWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+            Assert.That(gate.Observe(game), Is.False);
+            Assert.That(gate.Observe(game), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_NewWindowMustRemainStableBeforeRecordingStarts()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+        GameWindowSnapshot game = Snapshot(100, 20, "GameWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(game), Is.False);
+            Assert.That(gate.Observe(game), Is.True);
+            Assert.That(gate.IsReady, Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_TransientWindowThenDialogAgain_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+        GameWindowSnapshot transient = Snapshot(100, 30, "Tooltip", "", 200, 100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(transient), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+        });
+    }
+
+    [Test]
+    public void Observe_LauncherHandsOffToNewProcess_StartsAfterStableSample()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot launcher = Snapshot(100, 10, "Launcher", "Launcher", 600, 400);
+        GameWindowSnapshot game = Snapshot(200, 40, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(gate.Observe(launcher), Is.False);
+        Assert.That(gate.Observe(launcher), Is.False);
+        Assert.That(gate.Observe(game), Is.False);
+        Assert.That(gate.Observe(game), Is.True);
+    }
+
+    [Test]
+    public void HasMeaningfulTransition_SameWindowTitleOrSizeChangeIsIgnored()
+    {
+        GameWindowSnapshot baseline = Snapshot(100, 10, "Game", "Launcher", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "Game", "Actual game", 640, 480)), Is.False);
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "Game", "Launcher", 1280, 720)), Is.False);
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "GameWindow", "Launcher", 640, 480)), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_WindowDisappearsThenSameIdentityReturns_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot window = Snapshot(100, 10, "Game", "Launcher", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(null), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+        });
+    }
+
+    [Test]
+    public void Observe_FastConfirmationHistory_ReachesReadyBeforeConsumerStarts()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "TVPMainWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Observe(dialog), Is.False);
+            Assert.That(tracker.Observe(dialog), Is.False);
+            Assert.That(tracker.Observe(game), Is.False);
+            Assert.That(tracker.Observe(game), Is.True);
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.Ready));
+            Assert.That(tracker.ConfirmedSnapshot, Is.EqualTo(game));
+        });
+
+        Assert.That(tracker.DrainLogSnapshots(), Is.EqualTo(new[] { dialog, game }));
+    }
+
+    [Test]
+    public void Observe_NoPopupSingleWindow_RemainsBaselineWhenWaitingWasExplicitlyEnabled()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot game = Snapshot(200, 30, "GameWindow", "Game", 1280, 720);
+
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(game), Is.False);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+            Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Observe_ReplacementDialogWithoutTransition_RemainsPending()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot replacementDialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(replacementDialog), Is.False);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+            Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Observe_RejectedDialogDoesNotConfirmGameplayWindow()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(null), Is.False);
+
+        Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+    }
+
+    [Test]
+    public void Observe_ReplacementProcessGameWindow_UsesCompleteLaunchHistory()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(300, 30, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(game), Is.False);
+        Assert.That(tracker.Observe(game), Is.True);
+
+        Assert.That(tracker.ConfirmedSnapshot?.ProcessId, Is.EqualTo(300));
+    }
+
+    [Test]
+    public void Observe_LauncherThenStandardDialog_WaitsForFollowingGameWindow()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot launcher = Snapshot(100, 10, "LauncherWindow", "Launcher", 640, 480);
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(tracker.Observe(launcher), Is.False);
+        Assert.That(tracker.Observe(launcher), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        Assert.That(tracker.Observe(game), Is.False);
+        Assert.That(tracker.Observe(game), Is.True);
+
+        Assert.That(tracker.ConfirmedSnapshot, Is.EqualTo(game));
+    }
+
+    [Test]
+    public void StableProcessHandoffGate_RequiresTwoSamplesFromSameDifferentProcess()
+    {
+        StableProcessHandoffGate gate = new();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(100, 100), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, 300), Is.False);
+            Assert.That(gate.Observe(100, 300), Is.True);
+        });
+    }
+
+    [Test]
+    public void StableProcessHandoffGate_MissingForegroundProcessResetsCandidate()
+    {
+        StableProcessHandoffGate gate = new();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, null), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.True);
+        });
+    }
+
+    private static GameWindowSnapshot Snapshot(int processId, nint windowHandle, string className, string title,
+        int width, int height) => new(processId, windowHandle, className, title, width, height);
+}
+
+[TestFixture]
+public class StableGameWindowGateTest
+{
+    [Test]
+    public void Observe_RequiresTwoStableUsableSamples()
+    {
+        StableGameWindowGate gate = new();
+        GameWindowSnapshot window = new(42, (nint)123, "GameWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_ResetsWhenWindowChanges()
+    {
+        StableGameWindowGate gate = new();
+        GameWindowSnapshot first = new(42, (nint)123, "GameWindow", "Game", 1280, 720);
+        GameWindowSnapshot second = first with { WindowHandle = (nint)456 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(first), Is.False);
+            Assert.That(gate.Observe(second), Is.False);
+            Assert.That(gate.Observe(second), Is.True);
+        });
+    }
+}
+
+[TestFixture]
+public class GameSessionExitPolicyTest
+{
+    [TestCase(false, 0, 42, true)]
+    [TestCase(true, 0, 42, true)]
+    [TestCase(true, 99, 42, true)]
+    [TestCase(true, 42, 42, false)]
+    public void ShouldWaitForReplacement_OnlySkipsConfirmedGameplayPid(
+        bool recordingStarted,
+        int confirmedPid,
+        int exitedPid,
+        bool expected)
+    {
+        Assert.That(GameSessionExitPolicy.ShouldWaitForReplacement(recordingStarted, confirmedPid, exitedPid),
+            Is.EqualTo(expected));
+    }
+}

--- a/GalgameManager.Test/Models/GalgameInstallationTest.cs
+++ b/GalgameManager.Test/Models/GalgameInstallationTest.cs
@@ -174,6 +174,25 @@ public class GalgameInstallationTest
     }
 
     [Test]
+    public void LocalInstallationConfig_ClonePreservesLaunchDialogSetting()
+    {
+        LocalInstallationConfig config = new()
+        {
+            ExePath = @"D:\Library\Example\game.exe",
+            DelayPlayTimeUntilMainWindow = true,
+        };
+
+        LocalInstallationConfig clone = config.Clone();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone, Is.Not.SameAs(config));
+            Assert.That(clone.ExePath, Is.EqualTo(config.ExePath));
+            Assert.That(clone.DelayPlayTimeUntilMainWindow, Is.True);
+        });
+    }
+
+    [Test]
     public void VersionTwoMeta_PreservesOnlyItsInstallationConfiguration()
     {
         GameMetaBackup backup = new()

--- a/GalgameManager.Test/Services/BgTaskServiceTest.cs
+++ b/GalgameManager.Test/Services/BgTaskServiceTest.cs
@@ -84,6 +84,66 @@ public class BgTaskServiceTest : ServiceTestBase
         await addTask;
     }
 
+    [Test]
+    public async Task AddBgTask_ConcurrentDuplicates_OnlyOneRuns()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask[] tasks = Enumerable.Range(0, 32)
+            .Select(_ => new DeduplicatedTestBgTask("same", gate))
+            .ToArray();
+        var addedCount = 0;
+        service.BgTaskAdded += _ => Interlocked.Increment(ref addedCount);
+
+        Task[] additions = tasks.Select(service.AddBgTask).ToArray();
+        await Task.Delay(100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.GetBgTasks().Count(), Is.EqualTo(1));
+            Assert.That(tasks.Count(task => task.Ran), Is.EqualTo(1));
+            Assert.That(addedCount, Is.EqualTo(1));
+        });
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
+    [Test]
+    public async Task AddBgTask_DuplicateAfterCompletion_RunsAgain()
+    {
+        BgTaskService service = CreateService();
+        DeduplicatedTestBgTask first = new("same");
+        DeduplicatedTestBgTask second = new("same");
+
+        await service.AddBgTask(first);
+        await service.AddBgTask(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Ran, Is.True);
+            Assert.That(second.Ran, Is.True);
+            Assert.That(service.GetBgTasks(), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AddBgTask_DifferentDeduplicationKeys_RunTogether()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask first = new("first", gate);
+        DeduplicatedTestBgTask second = new("second", gate);
+
+        Task[] additions = [service.AddBgTask(first), service.AddBgTask(second)];
+        await Task.Delay(100);
+
+        Assert.That(service.GetBgTasks().Count(), Is.EqualTo(2));
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
     // 验证后台任务的持久化与恢复闭环：SaveBgTasksString把运行中的任务写入文件，
     // 新实例ResolvedBgTasksAsync读回、反序列化、RecoverFromJson并重新运行，最后删除文件
     [Test]
@@ -118,6 +178,34 @@ public class BgTaskServiceTest : ServiceTestBase
         // 等恢复的任务跑完并从列表移除，避免残留状态影响后续用例
         await Task.Delay(800);
         Assert.That(service2.GetBgTasks(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Resolve_DuplicatePersistedTasks_OnlyOneIsRestored()
+    {
+        RecoverableDeduplicatedTestBgTask.Reset();
+        BgTaskService service = CreateService();
+        service.RegisterBgTaskType(typeof(RecoverableDeduplicatedTestBgTask), "-dedupe");
+        string json = JsonConvert.SerializeObject(new RecoverableDeduplicatedTestBgTask
+        {
+            Key = "same",
+        });
+        string persisted = $"-dedupe {json.ToBase64()} -dedupe {json.ToBase64()} ";
+        _fileService.Save(AppStoragePaths.LocalDataPath, BgTaskFileName, persisted);
+        string file = Path.Combine(AppStoragePaths.LocalDataPath, BgTaskFileName);
+        for (var i = 0; i < 50 && !File.Exists(file); i++) await Task.Delay(100);
+
+        await service.ResolvedBgTasksAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RecoverableDeduplicatedTestBgTask.RunCount, Is.EqualTo(1));
+            Assert.That(service.GetBgTasks().OfType<RecoverableDeduplicatedTestBgTask>().Count(), Is.EqualTo(1));
+        });
+
+        RecoverableDeduplicatedTestBgTask.Gate.SetResult();
+        await Task.Delay(800);
+        Assert.That(service.GetBgTasks(), Is.Empty);
     }
 
     public class TestBgTask : BgTaskBase
@@ -160,5 +248,55 @@ public class BgTaskServiceTest : ServiceTestBase
         protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
 
         protected override Task RunInternal() => Task.CompletedTask;
+    }
+
+    public class DeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        private readonly TaskCompletionSource? _gate;
+
+        public DeduplicatedTestBgTask(string key, TaskCompletionSource? gate = null)
+        {
+            DeduplicationKey = key;
+            _gate = gate;
+        }
+
+        public string? DeduplicationKey { get; }
+        public bool Ran { get; private set; }
+        public override string Title => "DeduplicatedTestBgTask";
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Ran = true;
+            if (_gate is not null) await _gate.Task;
+        }
+    }
+
+    public class RecoverableDeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        public static TaskCompletionSource Gate { get; private set; } = NewGate();
+        public static int RunCount;
+
+        public string? Key { get; set; }
+        public string? DeduplicationKey => Key;
+        public override string Title => "RecoverableDeduplicatedTestBgTask";
+
+        public static void Reset()
+        {
+            Gate = NewGate();
+            RunCount = 0;
+        }
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Interlocked.Increment(ref RunCount);
+            await Gate.Task;
+        }
+
+        private static TaskCompletionSource NewGate() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/GalgameManager.WinApp.Base/Models/Sources/GalgameAndPath.cs
+++ b/GalgameManager.WinApp.Base/Models/Sources/GalgameAndPath.cs
@@ -136,6 +136,7 @@ public partial class LocalInstallationConfig : ObservableObject
     [ObservableProperty] private bool _highDpi; // 是否启用高DPI替代缩放
     [ObservableProperty] private GamePortablePath? _detectedSavePath; // 当前实例的探测存档路径
     [ObservableProperty] private string? _savePath; // 当前实例的云存档本地路径
+    [ObservableProperty] private bool _delayPlayTimeUntilMainWindow; // 声明/启动器窗口切换后再开始计时
     [ObservableProperty] private DateTime _lastSuccessfulLaunchTime = DateTime.MinValue; // 上次成功启动时间
 
     /// <summary>
@@ -153,6 +154,7 @@ public partial class LocalInstallationConfig : ObservableObject
         HighDpi = HighDpi,
         DetectedSavePath = DetectedSavePath,
         SavePath = SavePath,
+        DelayPlayTimeUntilMainWindow = DelayPlayTimeUntilMainWindow,
         LastSuccessfulLaunchTime = LastSuccessfulLaunchTime,
     };
 

--- a/GalgameManager/Helpers/GameLaunchWindowTracker.cs
+++ b/GalgameManager/Helpers/GameLaunchWindowTracker.cs
@@ -1,0 +1,101 @@
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 从游戏启动前开始保存安装目录中新进程的窗口变化，避免后台任务附着较晚时漏掉启动弹窗。
+/// </summary>
+public sealed class GameLaunchWindowTracker
+{
+    private static readonly TimeSpan InitialObservationInterval = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan StableObservationInterval = TimeSpan.FromMilliseconds(100);
+    private readonly object _syncRoot = new();
+    private readonly GameWindowTransitionGate _gate = new();
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly Queue<GameWindowSnapshot> _pendingLogSnapshots = new();
+    private GameWindowSnapshot? _lastLoggedSnapshot;
+    private GameWindowSnapshot? _confirmedSnapshot;
+    private Task? _observationTask;
+
+    public GameWindowTransitionStage Stage
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _gate.Stage;
+        }
+    }
+
+    public GameWindowSnapshot? ConfirmedSnapshot
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _confirmedSnapshot;
+        }
+    }
+
+    /// <summary>
+    /// 在启动操作执行前开始观察，确保短命启动进程退出前后的窗口都能进入同一段历史。
+    /// </summary>
+    public void Start(string directoryPrefix, IReadOnlyCollection<int> preExistingProcessIds)
+    {
+        lock (_syncRoot)
+        {
+            if (_observationTask is not null) return;
+            HashSet<int> excluded = new(preExistingProcessIds);
+            _observationTask = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!_cancellation.IsCancellationRequested && ConfirmedSnapshot is null)
+                    {
+                        GameWindowSnapshot? snapshot =
+                            GameProcessDetector.TryGetPrimaryWindowSnapshotInDirectory(directoryPrefix, excluded);
+                        _ = Observe(snapshot);
+                        TimeSpan interval = Stage == GameWindowTransitionStage.WaitingForBaseline
+                            ? InitialObservationInterval
+                            : StableObservationInterval;
+                        await Task.Delay(interval, _cancellation.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // 启动失败、任务结束或正式窗口已经确认时正常停止观察。
+                }
+            });
+        }
+    }
+
+    /// <summary>
+    /// 将已经附着进程的窗口也并入同一状态机，补足目录路径不可读取的受保护进程场景。
+    /// </summary>
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        lock (_syncRoot)
+        {
+            if (snapshot is { IsUsable: true } current &&
+                (!_lastLoggedSnapshot.HasValue ||
+                 GameWindowTransitionGate.HasMeaningfulTransition(_lastLoggedSnapshot.Value, current)))
+            {
+                _pendingLogSnapshots.Enqueue(current);
+                _lastLoggedSnapshot = current;
+            }
+
+            if (!_gate.Observe(snapshot) || !snapshot.HasValue) return false;
+            _confirmedSnapshot ??= snapshot.Value;
+            _cancellation.Cancel();
+            return true;
+        }
+    }
+
+    public IReadOnlyList<GameWindowSnapshot> DrainLogSnapshots()
+    {
+        lock (_syncRoot)
+        {
+            List<GameWindowSnapshot> result = [];
+            while (_pendingLogSnapshots.TryDequeue(out GameWindowSnapshot snapshot)) result.Add(snapshot);
+            return result;
+        }
+    }
+
+    public void Stop() => _cancellation.Cancel();
+}

--- a/GalgameManager/Helpers/GameProcessDetector.cs
+++ b/GalgameManager/Helpers/GameProcessDetector.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace GalgameManager.Helpers;
 
@@ -8,6 +10,41 @@ namespace GalgameManager.Helpers;
 /// </summary>
 public static class GameProcessDetector
 {
+    private delegate bool EnumWindowsProc(nint windowHandle, nint parameter);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(EnumWindowsProc callback, nint parameter);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(nint windowHandle);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(nint windowHandle, out uint processId);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(nint windowHandle, out NativeRect rect);
+
+    [DllImport("user32.dll")]
+    private static extern nint GetForegroundWindow();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(nint windowHandle, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(nint windowHandle, StringBuilder className, int maxCount);
+
     /// <summary>
     /// 在指定时间窗口内轮询，等待可执行文件路径位于游戏目录下的进程出现，返回最佳候选。
     /// </summary>
@@ -42,7 +79,7 @@ public static class GameProcessDetector
             }
             catch
             {
-                // ignored
+                // 单个进程拒绝访问时跳过，继续采集其余进程。
             }
             finally
             {
@@ -56,7 +93,8 @@ public static class GameProcessDetector
     /// 枚举可执行文件路径位于目录前缀下的进程，返回最佳候选（优先有主窗口的，其次启动时间最晚的）。
     /// </summary>
     public static Process? FindBestProcessInDirectory(string directoryPrefix,
-        IReadOnlyCollection<int>? excludeProcessIds = null)
+        IReadOnlyCollection<int>? excludeProcessIds = null,
+        string? requiredProcessName = null)
     {
         Process? best = null;
         foreach (Process process in Process.GetProcesses())
@@ -64,6 +102,9 @@ public static class GameProcessDetector
             try
             {
                 if (excludeProcessIds?.Contains(process.Id) == true ||
+                    (!string.IsNullOrWhiteSpace(requiredProcessName) &&
+                     !string.Equals(process.ProcessName, requiredProcessName,
+                         StringComparison.OrdinalIgnoreCase)) ||
                     !IsInDirectory(process, directoryPrefix))
                 {
                     process.Dispose();
@@ -101,6 +142,77 @@ public static class GameProcessDetector
     }
 
     /// <summary>
+    /// 获取安装目录内本次启动新出现进程的主要可见窗口。优先返回前台窗口，
+    /// 没有前台窗口时返回面积最大的窗口，用于在正式进程附着前保存启动窗口历史。
+    /// </summary>
+    public static GameWindowSnapshot? TryGetPrimaryWindowSnapshotInDirectory(string directoryPrefix,
+        IReadOnlyCollection<int>? excludeProcessIds = null)
+    {
+        nint foregroundWindow = GetForegroundWindow();
+        GameWindowSnapshot? foreground = null;
+        GameWindowSnapshot? largest = null;
+        long largestArea = -1;
+        HashSet<int> acceptedProcessIds = [];
+        HashSet<int> rejectedProcessIds = excludeProcessIds is null ? [] : new HashSet<int>(excludeProcessIds);
+        EnumWindowsProc callback = (windowHandle, _) =>
+        {
+            if (!IsWindowVisible(windowHandle) ||
+                GetWindowThreadProcessId(windowHandle, out uint rawProcessId) == 0 || rawProcessId == 0 ||
+                !GetWindowRect(windowHandle, out NativeRect rect)) return true;
+
+            int processId = unchecked((int)rawProcessId);
+            if (rejectedProcessIds.Contains(processId)) return true;
+            if (!acceptedProcessIds.Contains(processId))
+            {
+                try
+                {
+                    using Process process = Process.GetProcessById(processId);
+                    if (!IsInDirectory(process, directoryPrefix))
+                    {
+                        rejectedProcessIds.Add(processId);
+                        return true;
+                    }
+                    acceptedProcessIds.Add(processId);
+                }
+                catch
+                {
+                    rejectedProcessIds.Add(processId);
+                    return true;
+                }
+            }
+
+            int width = rect.Right - rect.Left;
+            int height = rect.Bottom - rect.Top;
+            if (width <= 0 || height <= 0) return true;
+
+            StringBuilder title = new(512);
+            StringBuilder className = new(256);
+            _ = GetWindowText(windowHandle, title, title.Capacity);
+            _ = GetClassName(windowHandle, className, className.Capacity);
+            GameWindowSnapshot snapshot = new(processId, windowHandle, className.ToString(), title.ToString(), width,
+                height);
+            if (windowHandle == foregroundWindow) foreground = snapshot;
+            long area = (long)width * height;
+            if (area > largestArea)
+            {
+                largestArea = area;
+                largest = snapshot;
+            }
+            return true;
+        };
+
+        try
+        {
+            _ = EnumWindows(callback, 0);
+            return foreground ?? largest;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// 将目录规范化为带结尾分隔符的完整路径前缀，避免把兄弟目录（如game2）误判为子路径。
     /// </summary>
     public static string GetDirectoryPrefix(string directory)
@@ -112,14 +224,70 @@ public static class GameProcessDetector
 
     public static bool IsAlive(Process process)
     {
+        int processId = SafeGetId(process);
         try
         {
             return !process.HasExited;
         }
         catch
         {
-            return false;
+            // 管理员或受保护进程可能拒绝 Process.HasExited 请求的句柄，
+            // 即使进程仍然存在。此时回退到系统进程快照，不能把拒绝访问当成退出。
+            return IsProcessIdPresent(processId);
         }
+    }
+
+    /// <summary>
+    /// 不打开目标进程查询句柄，直接从系统进程快照判断 PID 是否存在。
+    /// 即使 <see cref="Process.HasExited"/> 或 <see cref="Process.WaitForExitAsync(CancellationToken)"/> 被拒绝也可使用。
+    /// </summary>
+    public static bool IsProcessIdPresent(int processId)
+    {
+        if (processId <= 0) return false;
+        try
+        {
+            Process[] candidates = Process.GetProcesses();
+            try
+            {
+                foreach (Process candidate in candidates)
+                    if (candidate.Id == processId) return true;
+                return false;
+            }
+            finally
+            {
+                foreach (Process candidate in candidates) candidate.Dispose();
+            }
+        }
+        catch
+        {
+            // 快照采集失败不能证明某个具体进程仍然存活。
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 等待进程退出；Windows 拒绝为管理员进程授予等待或查询句柄时，
+    /// 回退到 PID 快照轮询。
+    /// </summary>
+    public static async Task WaitForExitSafelyAsync(Process process, CancellationToken cancellationToken = default)
+    {
+        int processId = SafeGetId(process);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+            return;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // ShellExecute 代理和管理员目标进程可能不提供可等待句柄。
+        }
+
+        while (IsProcessIdPresent(processId))
+            await Task.Delay(1000, cancellationToken);
     }
 
     public static bool HasWindow(Process process)
@@ -134,6 +302,79 @@ public static class GameProcessDetector
         }
     }
 
+    /// <summary>
+    /// 获取进程位于前台的可见顶层窗口；没有前台窗口时回退到面积最大的可见窗口。
+    /// 这里通过 user32 枚举窗口，不打开进程查询句柄，因此仍可观察管理员权限游戏。
+    /// </summary>
+    public static GameWindowSnapshot? TryGetPrimaryWindowSnapshot(Process process)
+    {
+        int processId = SafeGetId(process);
+        if (processId <= 0) return null;
+
+        nint foregroundWindow = GetForegroundWindow();
+        GameWindowSnapshot? foreground = null;
+        GameWindowSnapshot? largest = null;
+        long largestArea = -1;
+        EnumWindowsProc callback = (windowHandle, _) =>
+        {
+            if (!IsWindowVisible(windowHandle)) return true;
+            GetWindowThreadProcessId(windowHandle, out uint windowProcessId);
+            if (windowProcessId != (uint)processId || !GetWindowRect(windowHandle, out NativeRect rect)) return true;
+
+            int width = rect.Right - rect.Left;
+            int height = rect.Bottom - rect.Top;
+            if (width <= 0 || height <= 0) return true;
+
+            StringBuilder title = new(512);
+            StringBuilder className = new(256);
+            _ = GetWindowText(windowHandle, title, title.Capacity);
+            _ = GetClassName(windowHandle, className, className.Capacity);
+            GameWindowSnapshot snapshot = new(processId, windowHandle, className.ToString(), title.ToString(), width,
+                height);
+            if (windowHandle == foregroundWindow) foreground = snapshot;
+            long area = (long)width * height;
+            if (area > largestArea)
+            {
+                largestArea = area;
+                largest = snapshot;
+            }
+            return true;
+        };
+
+        try
+        {
+            _ = EnumWindows(callback, 0);
+            return foreground ?? largest;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 当前台窗口所属进程的可执行文件位于安装目录内时返回该进程。
+    /// 返回的 <see cref="Process"/> 实例由调用方负责释放。
+    /// </summary>
+    public static Process? TryGetForegroundProcessInDirectory(string directoryPrefix)
+    {
+        nint windowHandle = GetForegroundWindow();
+        if (windowHandle == 0 || GetWindowThreadProcessId(windowHandle, out uint processId) == 0 || processId == 0)
+            return null;
+
+        try
+        {
+            Process process = Process.GetProcessById((int)processId);
+            if (IsInDirectory(process, directoryPrefix)) return process;
+            process.Dispose();
+        }
+        catch
+        {
+            // 从查询 PID 到打开进程之间，前台窗口可能已经消失。
+        }
+        return null;
+    }
+
     public static int SafeGetId(Process process)
     {
         try
@@ -146,9 +387,15 @@ public static class GameProcessDetector
         }
     }
 
+    /// <summary>
+    /// 判断进程的可执行文件是否位于指定目录前缀内。
+    /// </summary>
+    public static bool IsProcessInDirectory(Process process, string directoryPrefix) =>
+        IsInDirectory(process, directoryPrefix);
+
     private static bool IsInDirectory(Process process, string directoryPrefix)
     {
-        if (process.HasExited) return false;
+        if (!IsAlive(process)) return false;
         string? path = process.TryGetExecutablePath();
         return path is not null && path.StartsWith(directoryPrefix, StringComparison.OrdinalIgnoreCase);
     }

--- a/GalgameManager/Helpers/GameRuntimeProcessRelay.cs
+++ b/GalgameManager/Helpers/GameRuntimeProcessRelay.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 在同一次游戏启动中共享已经确认的正式游戏进程，避免各后台任务独立判断进程接力。
+/// </summary>
+public sealed class GameRuntimeProcessRelay
+{
+    private readonly object _syncRoot = new();
+    private readonly TaskCompletionSource<Process?> _firstConfirmation =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Process? _confirmedProcess;
+    private bool _completed;
+
+    /// <summary>
+    /// 当前已经确认的正式游戏进程；尚未确认时返回 <see langword="null"/>。
+    /// </summary>
+    public Process? ConfirmedProcess
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _confirmedProcess;
+        }
+    }
+
+    /// <summary>
+    /// 计时任务是否已经结束，不会再确认新的游戏进程。
+    /// </summary>
+    public bool IsCompleted
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _completed;
+        }
+    }
+
+    /// <summary>
+    /// 发布由计时任务确认过的正式游戏进程。
+    /// </summary>
+    public void Confirm(Process process)
+    {
+        lock (_syncRoot)
+        {
+            if (_completed) return;
+            _confirmedProcess = process;
+            _firstConfirmation.TrySetResult(process);
+        }
+    }
+
+    /// <summary>
+    /// 等待第一个正式游戏进程；计时任务未确认进程便结束时返回 <see langword="null"/>。
+    /// </summary>
+    public Task<Process?> WaitForConfirmationAsync()
+    {
+        lock (_syncRoot)
+        {
+            if (_confirmedProcess is not null) return Task.FromResult<Process?>(_confirmedProcess);
+            if (_completed) return Task.FromResult<Process?>(null);
+            return _firstConfirmation.Task;
+        }
+    }
+
+    /// <summary>
+    /// 标记本次启动的进程跟踪已经结束。
+    /// </summary>
+    public void Complete()
+    {
+        lock (_syncRoot)
+        {
+            if (_completed) return;
+            _completed = true;
+            _firstConfirmation.TrySetResult(null);
+        }
+    }
+}

--- a/GalgameManager/Helpers/GameWindowTransitionGate.cs
+++ b/GalgameManager/Helpers/GameWindowTransitionGate.cs
@@ -1,0 +1,229 @@
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 用于区分启动弹窗和正式游戏窗口的可见顶层窗口快照。
+/// </summary>
+public readonly record struct GameWindowSnapshot(
+    int ProcessId,
+    nint WindowHandle,
+    string ClassName,
+    string Title,
+    int Width,
+    int Height)
+{
+    public bool IsUsable => ProcessId > 0 && WindowHandle != 0 && Width > 0 && Height > 0;
+}
+
+/// <summary>
+/// 启动窗口从首次出现到确认正式游戏的阶段。
+/// </summary>
+public enum GameWindowTransitionStage
+{
+    WaitingForBaseline,
+    WaitingForTransition,
+    ConfirmingGameplayWindow,
+    Ready,
+}
+
+/// <summary>
+/// 在观察到稳定且有意义的顶层窗口切换前保持预备计时状态。
+/// 此门控不依赖本地化窗口标题或可执行文件名。
+/// </summary>
+public sealed class GameWindowTransitionGate
+{
+    private const int RequiredStableSamples = 2;
+    private GameWindowSnapshot? _baseline;
+    private int _baselineSamples;
+    private GameWindowSnapshot? _candidate;
+    private int _candidateSamples;
+
+    public GameWindowTransitionStage Stage { get; private set; } = GameWindowTransitionStage.WaitingForBaseline;
+
+    public bool IsReady => Stage == GameWindowTransitionStage.Ready;
+
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        if (IsReady) return true;
+        if (!snapshot.HasValue || !snapshot.Value.IsUsable)
+        {
+            ResetCandidate();
+            return false;
+        }
+
+        GameWindowSnapshot current = snapshot.Value;
+        if (!_baseline.HasValue)
+        {
+            _baseline = current;
+            _baselineSamples = 1;
+            Stage = GameWindowTransitionStage.WaitingForBaseline;
+            return false;
+        }
+
+        bool sameBaselineWindow = IsSameWindowIdentity(_baseline.Value, current);
+        if (_baselineSamples < RequiredStableSamples)
+        {
+            if (sameBaselineWindow)
+            {
+                if (++_baselineSamples >= RequiredStableSamples)
+                    Stage = GameWindowTransitionStage.WaitingForTransition;
+            }
+            else
+            {
+                _baseline = current;
+                _baselineSamples = 1;
+                Stage = GameWindowTransitionStage.WaitingForBaseline;
+            }
+            ResetCandidate();
+            return false;
+        }
+
+        if (sameBaselineWindow)
+        {
+            ResetCandidate();
+            return false;
+        }
+
+        if (!_candidate.HasValue || !IsSameCandidate(_candidate.Value, current))
+        {
+            _candidate = current;
+            _candidateSamples = 1;
+            Stage = GameWindowTransitionStage.ConfirmingGameplayWindow;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        // 标准 Win32 对话框仍属于启动阶段。启动器先切到声明框时，不能把第一次窗口切换
+        // 直接当成正式游戏；将声明框提升为新基准后继续等待下一次非对话框切换。
+        if (IsStandardDialog(current))
+        {
+            _baseline = current;
+            _baselineSamples = RequiredStableSamples;
+            ResetCandidate();
+            return false;
+        }
+        Stage = GameWindowTransitionStage.Ready;
+        return true;
+    }
+
+    public static bool HasMeaningfulTransition(GameWindowSnapshot baseline, GameWindowSnapshot current)
+    {
+        if (!baseline.IsUsable || !current.IsUsable) return false;
+        return !IsSameWindowIdentity(baseline, current);
+    }
+
+    private static bool IsSameWindowIdentity(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal);
+
+    private static bool IsSameCandidate(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal) &&
+        string.Equals(left.Title.Trim(), right.Title.Trim(), StringComparison.Ordinal) &&
+        Math.Abs(left.Width - right.Width) < 16 &&
+        Math.Abs(left.Height - right.Height) < 16;
+
+    private static bool IsStandardDialog(GameWindowSnapshot snapshot) =>
+        string.Equals(snapshot.ClassName.Trim(), "#32770", StringComparison.Ordinal);
+
+    private void ResetCandidate()
+    {
+        _candidate = null;
+        _candidateSamples = 0;
+        if (_baselineSamples >= RequiredStableSamples)
+            Stage = GameWindowTransitionStage.WaitingForTransition;
+    }
+}
+
+/// <summary>
+/// 要求另一个前台进程连续保持稳定后，运行中的任务才接替到该进程。
+/// </summary>
+public sealed class StableProcessHandoffGate
+{
+    private const int RequiredStableSamples = 2;
+    private int _candidateProcessId;
+    private int _candidateSamples;
+
+    public bool Observe(int trackedProcessId, int? foregroundProcessId)
+    {
+        if (!foregroundProcessId.HasValue || foregroundProcessId.Value <= 0 ||
+            foregroundProcessId.Value == trackedProcessId)
+        {
+            Reset();
+            return false;
+        }
+
+        if (_candidateProcessId != foregroundProcessId.Value)
+        {
+            _candidateProcessId = foregroundProcessId.Value;
+            _candidateSamples = 1;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        Reset();
+        return true;
+    }
+
+    private void Reset()
+    {
+        _candidateProcessId = 0;
+        _candidateSamples = 0;
+    }
+}
+
+/// <summary>
+/// 直接启动的游戏窗口连续稳定两个采样周期后予以确认。
+/// 与 <see cref="GameWindowTransitionGate"/> 不同，此门控不要求先出现启动器到游戏的窗口切换。
+/// </summary>
+public sealed class StableGameWindowGate
+{
+    private const int RequiredStableSamples = 2;
+    private GameWindowSnapshot? _candidate;
+    private int _candidateSamples;
+
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        if (!snapshot.HasValue || !snapshot.Value.IsUsable)
+        {
+            Reset();
+            return false;
+        }
+
+        GameWindowSnapshot current = snapshot.Value;
+        if (!_candidate.HasValue || !IsSameWindow(_candidate.Value, current))
+        {
+            _candidate = current;
+            _candidateSamples = 1;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        Reset();
+        return true;
+    }
+
+    public void Reset()
+    {
+        _candidate = null;
+        _candidateSamples = 0;
+    }
+
+    private static bool IsSameWindow(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal) &&
+        Math.Abs(left.Width - right.Width) < 16 &&
+        Math.Abs(left.Height - right.Height) < 16;
+}
+
+public static class GameSessionExitPolicy
+{
+    /// <summary>
+    /// 只有尚未确认的启动阶段进程需要等待替代进程；已经确认的正式游戏 PID 退出后应立即结束。
+    /// </summary>
+    public static bool ShouldWaitForReplacement(bool recordingStarted, int confirmedGameplayProcessId,
+        int exitedProcessId) =>
+        !recordingStarted || confirmedGameplayProcessId <= 0 || confirmedGameplayProcessId != exitedProcessId;
+}

--- a/GalgameManager/Models/BgTasks/CallMagpieTask.cs
+++ b/GalgameManager/Models/BgTasks/CallMagpieTask.cs
@@ -15,13 +15,28 @@ public class CallMagpieTask : BgTaskBase
     public string ProcessName { get; set; } = null!;
     public bool HashFinished { get; set; }
     private Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
 
-    public CallMagpieTask() { } // Just for serialization
+    public CallMagpieTask() { } // 仅用于后台任务序列化恢复
 
     public CallMagpieTask(Galgame game, Process process)
+        : this(game, process, null)
+    {
+    }
+
+    public CallMagpieTask(Galgame game, Process process, GameRuntimeProcessRelay? processRelay)
     {
         Galgame = game;
         _process = process;
+        _processRelay = processRelay;
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器退出后仍等待计时任务发布正式游戏进程。
+        }
     }
     
     protected async override Task RecoverFromJsonInternal()
@@ -38,13 +53,30 @@ public class CallMagpieTask : BgTaskBase
             _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
             if (_process is null) throw new PvnException("Process not found");
         }
+        if (_processRelay is not null)
+        {
+            Process? confirmed = await _processRelay.WaitForConfirmationAsync();
+            if (confirmed is null || !GameProcessDetector.IsAlive(confirmed) || HashFinished)
+            {
+                ChangeProgress(1, 1, string.Empty, false);
+                return;
+            }
+            _process = confirmed;
+        }
         var magpiePath = await App.GetService<ILocalSettingsService>().ReadSettingAsync<string>(KeyValues.MagpiePath);
         if (string.IsNullOrEmpty(magpiePath)) throw new PvnException("CallMagpieTask_NoMagpiePath".GetLocalized());
         ChangeProgress(0, 1, "CallMagpieTask_LaunchingMagpie".GetLocalized());
         await MagpieHelper.LaunchMagpieAsync(magpiePath);
 
-        if (_process.HasExited || HashFinished) return;
-        ProcessName = _process.ProcessName;
+        if (!GameProcessDetector.IsAlive(_process) || HashFinished) return;
+        try
+        {
+            ProcessName = _process.ProcessName;
+        }
+        catch
+        {
+            // 受保护进程可能拒绝读取名称，仍继续尝试通过窗口调用 Magpie。
+        }
         for (var retry = 0; retry < MaxRetryCount && !HashFinished; retry++)
         {
             try
@@ -127,10 +159,10 @@ public static class MagpieHelper
         List<int> shortcuts = App.GetService<ILocalSettingsService>()
             .ReadSettingAsync<List<int>>(KeyValues.MagpieHotkeys).Result ?? [];
         InputSimulator keyboard = new();
-        // Press down all keys in the shortcut
+        // 依次按下快捷键。
         foreach (var shortcut in shortcuts)
             keyboard.Keyboard.KeyDown((VirtualKeyCode)shortcut);
-        // Release all keys in the shortcut (in reverse order is a common practice, though not strictly necessary for all cases)
+        // 按相反顺序释放快捷键。
         for (var i = shortcuts.Count - 1; i >= 0; i--)
             keyboard.Keyboard.KeyUp((VirtualKeyCode)shortcuts[i]);
     }

--- a/GalgameManager/Models/BgTasks/GameMuteTask.cs
+++ b/GalgameManager/Models/BgTasks/GameMuteTask.cs
@@ -11,15 +11,21 @@ public class GameMuteTask : BgTaskBase
     public int ProcessId { get; set; }
     public bool IsMuted { get; set; }
     private Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
 
-    public GameMuteTask() { } // For serialization
+    public GameMuteTask() { } // 仅用于后台任务序列化恢复
 
     public GameMuteTask(Galgame game, Process process)
+        : this(game, process, null)
+    {
+    }
+
+    public GameMuteTask(Galgame game, Process process, GameRuntimeProcessRelay? processRelay)
     {
         Galgame = game;
         _process = process;
-        ProcessName = process.ProcessName;
-        ProcessId = process.Id;
+        _processRelay = processRelay;
+        UpdateProcessIdentity(process);
     }
 
     protected override Task RecoverFromJsonInternal()
@@ -30,7 +36,7 @@ public class GameMuteTask : BgTaskBase
         }
         catch
         {
-            // Process might have exited, try to find by name
+            // 进程可能已经退出，回退到按名称查找。
             _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
         }
         return Task.CompletedTask;
@@ -42,19 +48,28 @@ public class GameMuteTask : BgTaskBase
         ChangeProgress(0, 1, "GameMuteTask_Starting".GetLocalized(Galgame.Name.Value!));
         
         // 确保开始时取消静音，防止上次异常退出导致的残留
-        AudioHelper.UnmuteProcess(_process.Id);
-        
-        while (!_process!.HasExited)
+        if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+
+        while (true)
         {
+            TryFollowConfirmedProcess();
+            Process? current = _process;
+            if (current is null || !GameProcessDetector.IsAlive(current))
+            {
+                if (_processRelay is null || _processRelay.IsCompleted) break;
+                await Task.Delay(200);
+                continue;
+            }
+
             try
             {
-                var shouldMute = !_process.IsMainWindowFocused();
+                bool shouldMute = !current.IsMainWindowFocused();
                 if (shouldMute)
                 {
                     // 需要静音
                     if (!IsMuted)
                     {
-                        if (AudioHelper.MuteProcess(_process.Id))
+                        if (AudioHelper.MuteProcess(current.Id))
                         {
                             IsMuted = true;
                             ChangeProgress(0, 1, "GameMuteTask_Muted".GetLocalized(Galgame.Name.Value!));
@@ -65,9 +80,9 @@ public class GameMuteTask : BgTaskBase
                 {
                     // 需要有声音 (在前台)
                     // 检查 IsMuted 标记或者系统实际状态
-                    if (IsMuted || AudioHelper.IsProcessMuted(_process.Id))
+                    if (IsMuted || AudioHelper.IsProcessMuted(current.Id))
                     {
-                        if (AudioHelper.UnmuteProcess(_process.Id))
+                        if (AudioHelper.UnmuteProcess(current.Id))
                         {
                             IsMuted = false;
                             ChangeProgress(0, 1, "GameMuteTask_Unmuted".GetLocalized(Galgame.Name.Value!));
@@ -87,8 +102,50 @@ public class GameMuteTask : BgTaskBase
         }
         
         // 结束时尝试取消静音
-        try { AudioHelper.UnmuteProcess(_process.Id); } catch { /* ignore */ }
+        try
+        {
+            if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+        }
+        catch
+        {
+            // 进程可能已退出，结束清理无需继续抛出异常。
+        }
         ChangeProgress(1, 1, string.Empty, false);
+    }
+
+    private void TryFollowConfirmedProcess()
+    {
+        Process? confirmed = _processRelay?.ConfirmedProcess;
+        if (confirmed is null || !GameProcessDetector.IsAlive(confirmed)) return;
+        int confirmedProcessId = GameProcessDetector.SafeGetId(confirmed);
+        if (confirmedProcessId <= 0 || confirmedProcessId == ProcessId) return;
+
+        try
+        {
+            if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+        }
+        catch
+        {
+            // 原启动器可能已经退出，切换进程时无需保留其静音状态。
+        }
+
+        _process = confirmed;
+        IsMuted = false;
+        UpdateProcessIdentity(confirmed);
+        AudioHelper.UnmuteProcess(ProcessId);
+    }
+
+    private void UpdateProcessIdentity(Process process)
+    {
+        ProcessId = GameProcessDetector.SafeGetId(process);
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器可能在任务创建前退出，稍后仍可接力到正式游戏进程。
+        }
     }
 
     public override string Title => "GameMuteTask_Title".GetLocalized();
@@ -105,7 +162,7 @@ public static class AudioHelper
     [DllImport("ole32.dll")]
     private static extern void CoUninitialize();
 
-    // Windows Core Audio API interfaces
+    // Windows Core Audio API 接口
     [ComImport]
     [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
     private class MMDeviceEnumerator

--- a/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
+++ b/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
@@ -1,0 +1,12 @@
+namespace GalgameManager.Models.BgTasks;
+
+/// <summary>
+/// 标记活动期间必须保持逻辑唯一的后台任务。
+/// </summary>
+public interface IDeduplicatedBgTask
+{
+    /// <summary>
+    /// 获取任务类型内的逻辑标识；空值表示不启用去重。
+    /// </summary>
+    string? DeduplicationKey { get; }
+}

--- a/GalgameManager/Models/BgTasks/KeyMappingTask.cs
+++ b/GalgameManager/Models/BgTasks/KeyMappingTask.cs
@@ -17,14 +17,18 @@ public class KeyMappingTask : BgTaskBase
     public Galgame? Galgame;
     public override bool ProgressOnTrayIcon => false;
     public List<KeyMapping> KeyMappings { get; set; } = new();
+    public bool HasPreLaunchProcessSnapshot { get; set; } // 是否已经在启动游戏前采集安装目录进程快照
+    public List<int> PreExistingProcessIds { get; set; } = []; // 启动前已经存在于安装目录的进程Id
 
-    private Process? _process;
+    private volatile Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
     private string[] _directoryPrefixes = [];
     private readonly HashSet<int> _trackedProcessIds = [];
     private List<KeyMapping> _runtimeGameMappings = [];
     private bool _runtimeGameMappingOptInEnabled;
     private KeyMappingRuntimeSnapshot _snapshot = KeyMappingRuntimeSnapshot.Empty;
     private KeyMappingRuntimeSnapshot? _pendingSnapshot;
+    private volatile int _confirmedGameplayProcessId;
     private readonly Dictionary<int, KeyMappingOutput> _activeKeyboardMappings = new();
     private readonly Dictionary<int, KeyMappingOutput> _activeMouseMappings = new();
     private readonly HashSet<int> _pressedPhysicalKeyboardKeys = [];
@@ -149,12 +153,30 @@ public class KeyMappingTask : BgTaskBase
     }
 
     public KeyMappingTask(Galgame game, Process process, IEnumerable<KeyMapping> keyMappings)
+        : this(game, process, keyMappings, null, null)
+    {
+    }
+
+    public KeyMappingTask(Galgame game, Process process, IEnumerable<KeyMapping> keyMappings,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay)
         : this()
     {
-        ProcessName = process.ProcessName;
         Galgame = game;
         _process = process;
+        _processRelay = processRelay;
+        HasPreLaunchProcessSnapshot = preExistingProcessIds is not null;
+        PreExistingProcessIds = preExistingProcessIds?.ToList() ?? [];
+        foreach (int processId in PreExistingProcessIds)
+            _trackedProcessIds.Add(processId);
         _trackedProcessIds.Add(GameProcessDetector.SafeGetId(process));
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器可能在任务创建前已经退出，仍保留任务以便接力到正式游戏进程。
+        }
         KeyMappings = keyMappings.Select(m => new KeyMapping
         {
             From = new List<int>(m.From),
@@ -171,6 +193,8 @@ public class KeyMappingTask : BgTaskBase
     protected override Task RecoverFromJsonInternal()
     {
         _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
+        HasPreLaunchProcessSnapshot = false;
+        PreExistingProcessIds = [];
         if (_process is not null) _trackedProcessIds.Add(GameProcessDetector.SafeGetId(_process));
         InitDirectoryPrefixes();
         return Task.CompletedTask;
@@ -364,23 +388,51 @@ public class KeyMappingTask : BgTaskBase
     {
         while (_process is not null)
         {
-            try
+            TryFollowConfirmedProcess();
+            Process? tracked = _process;
+            if (tracked is null) break;
+            while (ReferenceEquals(_process, tracked) && GameProcessDetector.IsAlive(tracked))
             {
-                await _process.WaitForExitAsync();
+                TryFollowConfirmedProcess();
+                await Task.Delay(200);
             }
-            catch
-            {
-                // ShellExecute 和快捷方式返回的 Process 可能无法等待，交给目录探测兜底。
-            }
+            if (!ReferenceEquals(_process, tracked)) continue;
 
-            int exitedProcessId = GameProcessDetector.SafeGetId(_process);
+            int exitedProcessId = GameProcessDetector.SafeGetId(tracked);
             if (exitedProcessId > 0) _trackedProcessIds.Add(exitedProcessId);
+            if (!GameSessionExitPolicy.ShouldWaitForReplacement(
+                    _confirmedGameplayProcessId > 0, _confirmedGameplayProcessId, exitedProcessId))
+                break;
             Process? replacement = await WaitForReplacementProcessAsync();
             if (replacement is null) break;
 
-            _process = replacement;
-            ProcessName = replacement.ProcessName;
-            _trackedProcessIds.Add(replacement.Id);
+            AttachProcess(replacement);
+        }
+    }
+
+    private void TryFollowConfirmedProcess()
+    {
+        Process? confirmed = _processRelay?.ConfirmedProcess;
+        if (confirmed is null || !GameProcessDetector.IsAlive(confirmed)) return;
+        int confirmedProcessId = GameProcessDetector.SafeGetId(confirmed);
+        if (confirmedProcessId <= 0) return;
+
+        _confirmedGameplayProcessId = confirmedProcessId;
+        if (_process is not null && GameProcessDetector.SafeGetId(_process) == confirmedProcessId) return;
+        AttachProcess(confirmed);
+    }
+
+    private void AttachProcess(Process process)
+    {
+        _process = process;
+        _trackedProcessIds.Add(GameProcessDetector.SafeGetId(process));
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 进程可能在身份切换期间退出，后续仍由生命周期检查完成清理。
         }
     }
 
@@ -636,7 +688,9 @@ public class KeyMappingTask : BgTaskBase
 
         try
         {
-            if (_process is { HasExited: false } && _process.Id == foregroundProcessId)
+            Process? tracked = _process;
+            if (tracked is not null && GameProcessDetector.IsAlive(tracked) &&
+                GameProcessDetector.SafeGetId(tracked) == foregroundProcessId)
             {
                 matchReason = "跟踪进程一致";
                 return true;

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -20,14 +20,26 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     public DateTime StartTime { get; set; }= DateTime.Now;
     public int CurrentPlayTime { get; set; } //本次游玩时间
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
+    public bool HasPreLaunchProcessSnapshot { get; set; } // 是否已经在启动游戏前采集安装目录进程快照
+    public List<int> PreExistingProcessIds { get; set; } = []; // 启动前已经存在于安装目录的进程Id
+    public bool DelayPlayTimeUntilMainWindow { get; set; } // 等待声明/启动器窗口切换后再开始计时
     public override bool ProgressOnTrayIcon => true;
     public string? DeduplicationKey => Galgame?.Uuid.ToString("D");
 
     public Galgame? Galgame;
-    private Process? _process;
+    private volatile Process? _process;
     private string? _directoryPrefix; // 安装目录前缀，用于退出后探测新出现的游戏进程
     private HashSet<int>? _knownProcessIds; // 开始跟踪时已存在于安装目录的进程，复查时只附着新出现的进程
+    private readonly object _knownProcessIdsLock = new();
     private volatile bool _stopped;
+    private bool _recoveredFromJson;
+    private volatile bool _recordingStarted;
+    private volatile int _confirmedGameplayProcessId;
+    private readonly StableProcessHandoffGate _foregroundProcessHandoffGate = new();
+    private readonly StableGameWindowGate _directWindowGate = new();
+    private GameRuntimeProcessRelay? _processRelay;
+    private GameWindowSnapshot? _initialWindowSnapshot;
+    private GameLaunchWindowTracker? _launchWindowTracker;
 
     private readonly ILocalSettingsService _localSettingsService = App.GetService<ILocalSettingsService>();
     private readonly IGalgameCollectionService _gameService = App.GetService<IGalgameCollectionService>();
@@ -52,26 +64,81 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     /// <param name="process">要跟踪的游戏进程</param>
     /// <param name="installationId">本次游玩使用的安装实例Id</param>
     public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId)
+        : this(game, process, installationId, null, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用启动前进程快照和运行时进程接力创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay)
+        : this(game, process, installationId, preExistingProcessIds, processRelay, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用启动前进程快照、运行时接力和任务创建时的窗口快照创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    /// <param name="initialWindowSnapshot">创建后台任务前捕获到的首个窗口</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay,
+        GameWindowSnapshot? initialWindowSnapshot)
+        : this(game, process, installationId, preExistingProcessIds, processRelay, initialWindowSnapshot, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用完整启动上下文创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    /// <param name="initialWindowSnapshot">创建后台任务前捕获到的首个窗口</param>
+    /// <param name="launchWindowTracker">从启动动作前开始保存窗口变化的追踪器</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay,
+        GameWindowSnapshot? initialWindowSnapshot, GameLaunchWindowTracker? launchWindowTracker)
     {
         Debug.Assert(game.IsLocalGame);
+        Galgame = game;
+        _process = process;
+        _processRelay = processRelay;
+        _initialWindowSnapshot = initialWindowSnapshot;
+        _launchWindowTracker = launchWindowTracker;
+        InstallationId = installationId;
+        HasPreLaunchProcessSnapshot = preExistingProcessIds is not null;
+        PreExistingProcessIds = preExistingProcessIds?.ToList() ?? [];
         try
         {
-            if (process.HasExited) return;
             ProcessName = process.ProcessName;
         }
         catch
         {
-            // 进程对象可能无效（例如通过ShellExecute启动的快捷方式），仍创建任务，由退出后的目录检查兜底
+            // 进程对象可能无效（例如通过 ShellExecute 启动的快捷方式），仍创建任务，由目录检查兜底。
         }
-        Galgame = game;
-        _process = process;
-        InstallationId = installationId;
+        DelayPlayTimeUntilMainWindow = game.SourceEntries.FirstOrDefault(e => e.EntryId == installationId)
+            ?.LocalConfig?.DelayPlayTimeUntilMainWindow == true;
         InitDirectoryWatch();
     }
 
     protected override Task RecoverFromJsonInternal()
     {
+        _recoveredFromJson = true;
         _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
+        HasPreLaunchProcessSnapshot = false;
         InitDirectoryWatch();
         return Task.CompletedTask;
     }
@@ -81,32 +148,71 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
         string? path = Galgame?.SourceEntries.FirstOrDefault(e => e.EntryId == InstallationId)?.Path;
         if (string.IsNullOrEmpty(path)) return;
         _directoryPrefix = GameProcessDetector.GetDirectoryPrefix(path);
-        _knownProcessIds = GameProcessDetector.GetProcessIdsInDirectory(_directoryPrefix);
+        _knownProcessIds = HasPreLaunchProcessSnapshot
+            ? new HashSet<int>(PreExistingProcessIds)
+            : GameProcessDetector.GetProcessIdsInDirectory(_directoryPrefix);
     }
 
-    protected async override Task RunInternal()
+    protected override async Task RunInternal()
+    {
+        try
+        {
+            await RunCoreAsync();
+        }
+        finally
+        {
+            _launchWindowTracker?.Stop();
+            _processRelay?.Complete();
+        }
+    }
+
+    private async Task RunCoreAsync()
     {
         if(_process is null || Galgame is null) return ;
         ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
         Task t = Task.Run(async () =>
         {
-            // 被跟踪的进程退出后，游戏目录内可能出现真正的游戏进程（启动器场景），尝试重新附着
             while (true)
             {
+                Process? tracked = _process;
+                if (tracked is null) break;
+                int trackedProcessId = GameProcessDetector.SafeGetId(tracked);
+                while (ReferenceEquals(_process, tracked) && GameProcessDetector.IsAlive(tracked))
+                {
+                    if (_confirmedGameplayProcessId <= 0)
+                    {
+                        TryAttachStableForegroundProcess(_foregroundProcessHandoffGate);
+                        TryConfirmDirectGameplayProcess(_process);
+                    }
+                    await Task.Delay(500);
+                }
+
+                if (!ReferenceEquals(_process, tracked)) continue;
+                if (!GameSessionExitPolicy.ShouldWaitForReplacement(
+                        _recordingStarted, _confirmedGameplayProcessId, trackedProcessId))
+                {
+                    App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+                        $"Confirmed gameplay process exited; finishing immediately: gameUuid={Galgame.Uuid:D}, " +
+                        $"installationId={InstallationId:D}, pid={trackedProcessId}");
+                    break;
+                }
+
+                Process? next;
                 try
                 {
-                    await _process.WaitForExitAsync();
+                    next = await WaitForReplacementProcessAsync(trackedProcessId);
                 }
                 catch
                 {
-                    // 进程对象无效（例如通过ShellExecute启动的快捷方式），直接进行目录检查
+                    next = null;
                 }
-                Process? next = await WaitForReplacementProcessAsync(GameProcessDetector.SafeGetId(_process));
+                if (!ReferenceEquals(_process, tracked))
+                {
+                    next?.Dispose();
+                    continue;
+                }
                 if (next is null) break;
-                _process = next;
-                ProcessName = next.ProcessName;
-                _knownProcessIds?.Add(next.Id);
-                ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
+                AttachProcess(next, "previous process exited");
             }
             _stopped = true;
             var windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
@@ -148,15 +254,19 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     private async Task<Process?> WaitForReplacementProcessAsync(int exitedProcessId)
     {
         if (_directoryPrefix is null || _knownProcessIds is null) return null;
-        _knownProcessIds.Add(exitedProcessId);
+        lock (_knownProcessIdsLock)
+            _knownProcessIds.Add(exitedProcessId);
         for (int i = 0; i < 5; i++)
         {
             ChangeProgress(0, 1,
                 "RecordPlayTimeTask_WaitingForProcess".GetLocalized(Galgame!.Name.Value ?? string.Empty,
                     (5 - i).ToString()));
             await Task.Delay(1000);
+            int[] excludedProcessIds;
+            lock (_knownProcessIdsLock)
+                excludedProcessIds = _knownProcessIds.ToArray();
             Process? candidate =
-                GameProcessDetector.FindBestProcessInDirectory(_directoryPrefix, _knownProcessIds);
+                GameProcessDetector.FindBestProcessInDirectory(_directoryPrefix, excludedProcessIds);
             if (candidate is not null) return candidate;
         }
         return null;
@@ -169,6 +279,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             var recordOnlyWhenForeground =
                 await _localSettingsService.ReadSettingAsync<bool>(KeyValues.RecordOnlyWhenForeground);
             _minPlayTimeRecordThreshold = await _localSettingsService.ReadSettingAsync<int>(KeyValues.MinPlayTimeRecordThreshold);
+            if (!await WaitForPlayableWindowAsync()) return;
             try
             {
                 _localSettingsService.OnSettingChanged += OnSettingChanged;
@@ -210,6 +321,170 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 
     public override bool OnSearch(string key) =>
         Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
+
+    private void TryConfirmDirectGameplayProcess(Process? process)
+    {
+        if (!_recordingStarted || process is null || !GameProcessDetector.IsAlive(process)) return;
+        // 启用弹窗等待的安装实例只能由窗口切换门控确认。恢复任务缺少启动前快照，
+        // 此时将稳定存在的游戏窗口作为最安全的确认依据。
+        if (DelayPlayTimeUntilMainWindow && !_recoveredFromJson) return;
+
+        GameWindowSnapshot? snapshot = GameProcessDetector.TryGetPrimaryWindowSnapshot(process);
+        if (!_directWindowGate.Observe(snapshot) || !snapshot.HasValue) return;
+        if (_confirmedGameplayProcessId == snapshot.Value.ProcessId) return;
+
+        _confirmedGameplayProcessId = snapshot.Value.ProcessId;
+        PublishGameplayProcess(process, _confirmedGameplayProcessId);
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Gameplay process confirmed by stable window: gameUuid={Galgame!.Uuid:D}, " +
+            $"installationId={InstallationId:D}, pid={_confirmedGameplayProcessId}");
+    }
+
+    private async Task<bool> WaitForPlayableWindowAsync()
+    {
+        // 恢复任务可能已经附着到正式游戏窗口，但无法还原启动前快照；
+        // 若仍等待窗口切换，PotatoVN 重启后可能永远无法开始计时。
+        if (!DelayPlayTimeUntilMainWindow || _recoveredFromJson)
+        {
+            _recordingStarted = true;
+            return true;
+        }
+
+        bool hasPreLaunchTracker = _launchWindowTracker is not null;
+        GameLaunchWindowTracker tracker = _launchWindowTracker ??= new GameLaunchWindowTracker();
+        if (_initialWindowSnapshot is { } initialSnapshot)
+        {
+            _ = tracker.Observe(initialSnapshot);
+            _initialWindowSnapshot = null;
+        }
+        ChangeProgress(0, 1,
+            "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
+        while (!_stopped)
+        {
+            Process? current = _process;
+            GameWindowSnapshot? snapshot = current is not null && GameProcessDetector.IsAlive(current)
+                ? GameProcessDetector.TryGetPrimaryWindowSnapshot(current)
+                : null;
+            // 启动前追踪器会同时观察安装目录中的替代进程；当前短命进程没有窗口，
+            // 不能用它的空快照清除另一个进程中已经捕获到的正式窗口候选。
+            if (snapshot.HasValue || !hasPreLaunchTracker) _ = tracker.Observe(snapshot);
+            foreach (GameWindowSnapshot observed in tracker.DrainLogSnapshots()) LogWindowObservation(observed);
+
+            GameWindowSnapshot? confirmedSnapshot = tracker.ConfirmedSnapshot;
+            if (confirmedSnapshot.HasValue && TryAttachConfirmedGameplayProcess(confirmedSnapshot.Value))
+            {
+                _recordingStarted = true;
+                _confirmedGameplayProcessId = confirmedSnapshot.Value.ProcessId;
+                Process? confirmedProcess = _process;
+                if (confirmedProcess is not null)
+                    PublishGameplayProcess(confirmedProcess, _confirmedGameplayProcessId);
+                ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
+                App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+                    $"Play-time recording started after window transition: gameUuid={Galgame.Uuid:D}, " +
+                    $"installationId={InstallationId:D}, pid={_confirmedGameplayProcessId}");
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private bool TryAttachConfirmedGameplayProcess(GameWindowSnapshot confirmedSnapshot)
+    {
+        Process? current = _process;
+        if (current is not null && GameProcessDetector.SafeGetId(current) == confirmedSnapshot.ProcessId)
+            return GameProcessDetector.IsAlive(current);
+
+        Process? confirmedProcess = null;
+        try
+        {
+            confirmedProcess = Process.GetProcessById(confirmedSnapshot.ProcessId);
+            if (!GameProcessDetector.IsAlive(confirmedProcess) ||
+                (_directoryPrefix is not null &&
+                 !GameProcessDetector.IsProcessInDirectory(confirmedProcess, _directoryPrefix)))
+            {
+                confirmedProcess.Dispose();
+                return false;
+            }
+            AttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
+            return true;
+        }
+        catch
+        {
+            confirmedProcess?.Dispose();
+            return false;
+        }
+    }
+
+    private void PublishGameplayProcess(Process process, int processId)
+    {
+        if (processId > 0 && GameProcessDetector.SafeGetId(process) == processId)
+            _processRelay?.Confirm(process);
+    }
+
+    private void TryAttachStableForegroundProcess(StableProcessHandoffGate handoffGate)
+    {
+        if (_directoryPrefix is null) return;
+        Process? foreground = GameProcessDetector.TryGetForegroundProcessInDirectory(_directoryPrefix);
+        if (foreground is null)
+        {
+            int currentProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+            _ = handoffGate.Observe(currentProcessId, null);
+            return;
+        }
+
+        int trackedProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+        int foregroundProcessId = GameProcessDetector.SafeGetId(foreground);
+        bool existedBeforeLaunch;
+        lock (_knownProcessIdsLock)
+            existedBeforeLaunch = _knownProcessIds?.Contains(foregroundProcessId) == true;
+        if (existedBeforeLaunch)
+        {
+            _ = handoffGate.Observe(trackedProcessId, null);
+            foreground.Dispose();
+            return;
+        }
+        if (!handoffGate.Observe(trackedProcessId, foregroundProcessId))
+        {
+            foreground.Dispose();
+            return;
+        }
+
+        AttachProcess(foreground, "stable foreground process in installation directory");
+    }
+
+    private void AttachProcess(Process process, string reason)
+    {
+        int previousProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+        _process = process;
+        _confirmedGameplayProcessId = 0;
+        _directWindowGate.Reset();
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 进程可能在接替期间退出，后续生命周期检查会继续处理。
+        }
+        lock (_knownProcessIdsLock)
+            _knownProcessIds?.Add(GameProcessDetector.SafeGetId(process));
+        ChangeProgress(0, 1, _recordingStarted
+            ? "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame!.Name.Value!)
+            : "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Play-time process attached: gameUuid={Galgame.Uuid:D}, installationId={InstallationId:D}, " +
+            $"previousPid={previousProcessId}, pid={GameProcessDetector.SafeGetId(process)}, " +
+            $"process={ProcessName}, reason={reason}");
+    }
+
+    private void LogWindowObservation(GameWindowSnapshot snapshot)
+    {
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Play-time window observed: gameUuid={Galgame!.Uuid:D}, installationId={InstallationId:D}, " +
+            $"pid={snapshot.ProcessId}, hwnd=0x{snapshot.WindowHandle:X}, class={snapshot.ClassName}, " +
+            $"size={snapshot.Width}x{snapshot.Height}, title={snapshot.Title}");
+    }
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -12,7 +12,7 @@ using GalgameManager.WinApp.Base.Models.Msgs;
 
 namespace GalgameManager.Models.BgTasks;
 
-public class RecordPlayTimeTask : BgTaskBase
+public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 {
     private const int ManuallySelectProcessSec = 15; //认定为需要手动选择游戏进程的时间阈值
 
@@ -21,6 +21,7 @@ public class RecordPlayTimeTask : BgTaskBase
     public int CurrentPlayTime { get; set; } //本次游玩时间
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
     public override bool ProgressOnTrayIcon => true;
+    public string? DeduplicationKey => Galgame?.Uuid.ToString("D");
 
     public Galgame? Galgame;
     private Process? _process;
@@ -206,6 +207,9 @@ public class RecordPlayTimeTask : BgTaskBase
             }
         });
     }
+
+    public override bool OnSearch(string key) =>
+        Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -212,7 +212,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                     continue;
                 }
                 if (next is null) break;
-                AttachProcess(next, "previous process exited");
+                if (!TryAttachProcess(next, "previous process exited")) continue;
             }
             _stopped = true;
             var windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
@@ -406,8 +406,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                 confirmedProcess.Dispose();
                 return false;
             }
-            AttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
-            return true;
+            return TryAttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
         }
         catch
         {
@@ -450,32 +449,47 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             return;
         }
 
-        AttachProcess(foreground, "stable foreground process in installation directory");
+        _ = TryAttachProcess(foreground, "stable foreground process in installation directory");
     }
 
-    private void AttachProcess(Process process, string reason)
+    private bool TryAttachProcess(Process process, string reason)
     {
+        int processId = GameProcessDetector.SafeGetId(process);
+        string processName;
+        try
+        {
+            processName = process.ProcessName;
+        }
+        catch
+        {
+            lock (_knownProcessIdsLock)
+                if (processId > 0) _knownProcessIds?.Add(processId);
+            process.Dispose();
+            return false;
+        }
+        if (processId <= 0 || !GameProcessDetector.IsAlive(process))
+        {
+            lock (_knownProcessIdsLock)
+                if (processId > 0) _knownProcessIds?.Add(processId);
+            process.Dispose();
+            return false;
+        }
+
         int previousProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
         _process = process;
         _confirmedGameplayProcessId = 0;
         _directWindowGate.Reset();
-        try
-        {
-            ProcessName = process.ProcessName;
-        }
-        catch
-        {
-            // 进程可能在接替期间退出，后续生命周期检查会继续处理。
-        }
+        ProcessName = processName;
         lock (_knownProcessIdsLock)
-            _knownProcessIds?.Add(GameProcessDetector.SafeGetId(process));
+            _knownProcessIds?.Add(processId);
         ChangeProgress(0, 1, _recordingStarted
             ? "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame!.Name.Value!)
             : "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
         App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
             $"Play-time process attached: gameUuid={Galgame.Uuid:D}, installationId={InstallationId:D}, " +
-            $"previousPid={previousProcessId}, pid={GameProcessDetector.SafeGetId(process)}, " +
+            $"previousPid={previousProcessId}, pid={processId}, " +
             $"process={ProcessName}, reason={reason}");
+        return true;
     }
 
     private void LogWindowObservation(GameWindowSnapshot snapshot)

--- a/GalgameManager/Services/BgTaskService.cs
+++ b/GalgameManager/Services/BgTaskService.cs
@@ -132,9 +132,29 @@ public class BgTaskService : IBgTaskService
     {
         try
         {
+            string? rejectedDuplicateKey = null;
             lock (_bgTasksLock)
             {
-                _bgTasks.Add(bgTask);
+                if (bgTask is IDeduplicatedBgTask { DeduplicationKey: { Length: > 0 } key } &&
+                    _bgTasks.Any(existing => existing.GetType() == bgTask.GetType() &&
+                                             existing is IDeduplicatedBgTask deduplicated &&
+                                             string.Equals(deduplicated.DeduplicationKey, key,
+                                                 StringComparison.Ordinal)))
+                {
+                    rejectedDuplicateKey = key;
+                }
+                else
+                {
+                    _bgTasks.Add(bgTask);
+                }
+            }
+
+            if (rejectedDuplicateKey is not null)
+            {
+                _infoService.DeveloperEvent(
+                    msg: $"Ignored duplicate background task: type={bgTask.GetType().Name}, " +
+                         $"key={rejectedDuplicateKey}");
+                return Task.CompletedTask;
             }
 
             if (bgTask.ProgressOnTrayIcon)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -94,11 +94,17 @@ public sealed class GameLaunchService(
             if (string.IsNullOrEmpty(config.ExePath)) return;
         }
 
+        GameRuntimeProcessRelay processRelay = new();
         Process? process = null;
+        IReadOnlyCollection<int> preExistingProcessIds = [];
+        GameLaunchWindowTracker? launchWindowTracker = null;
         try
         {
             if (isSteam)
             {
+                preExistingProcessIds = GameProcessDetector.GetProcessIdsInDirectory(
+                    GameProcessDetector.GetDirectoryPrefix(installation.Path));
+                launchWindowTracker = StartLaunchWindowTracker(config, installation.Path, preExistingProcessIds);
                 Uri steamUri = new($"steam://run/{game.Ids[(int)RssType.Steam]}");
                 infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
                     msg: "GalgamePage_Play_StartingSteam".GetLocalized());
@@ -118,11 +124,11 @@ public sealed class GameLaunchService(
                     {
                         if (!await DisplaySteamMessageAsync()) return;
                         if (!await SelectProcessAsync(config)) return;
-                        process = await WaitForProcessStartAsync(config.ProcessName!);
+                        process = await WaitForProcessStartAsync(config.ProcessName!, preExistingProcessIds);
                     }
                 }
                 else
-                    process = await WaitForProcessStartAsync(config.ProcessName);
+                    process = await WaitForProcessStartAsync(config.ProcessName, preExistingProcessIds);
             }
             else
             {
@@ -152,13 +158,16 @@ public sealed class GameLaunchService(
                     Verb = config.RunAsAdmin ? "runas" : null,
                 };
                 if (arguments is not null) startInfo.ArgumentList.Add(arguments);
+                preExistingProcessIds = GameProcessDetector.GetProcessIdsInDirectory(
+                    GameProcessDetector.GetDirectoryPrefix(installation.Path));
+                launchWindowTracker = StartLaunchWindowTracker(config, installation.Path, preExistingProcessIds);
                 process = new Process { StartInfo = startInfo };
                 process.Start();
 
-                if (!string.IsNullOrEmpty(config.ProcessName))
+                if (!string.IsNullOrEmpty(config.ProcessName) &&
+                    !ProcessMatchesConfiguredName(process, config.ProcessName))
                 {
-                    await Task.Delay(2000);
-                    process = await WaitForProcessStartAsync(config.ProcessName) ?? process;
+                    process = await WaitForProcessStartAsync(config.ProcessName, preExistingProcessIds) ?? process;
                 }
                 // 未指定进程名时直接跟踪启动的进程；若是启动器，
                 // RecordPlayTimeTask会在其退出后探测安装目录内新出现的进程并重新附着
@@ -177,27 +186,32 @@ public sealed class GameLaunchService(
             if (installation.Source is not null) sourceCollectionService.Save(installation.Source);
             await _gameService.SaveGalgameAsync(game);
 
-            _ = bgTaskService.AddBgTask(new RecordPlayTimeTask(game, process, installation.EntryId));
+            GameWindowSnapshot? initialWindowSnapshot = GameProcessDetector.TryGetPrimaryWindowSnapshot(process);
+            _ = bgTaskService.AddBgTask(new RecordPlayTimeTask(game, process, installation.EntryId,
+                preExistingProcessIds, processRelay, initialWindowSnapshot, launchWindowTracker));
+            // 计时任务接管启动窗口追踪器；启动服务提前结束时不能停止仍在等待接力的观察。
+            launchWindowTracker = null;
             // 即使当前没有生效规则，也保留轻量运行时任务，
             // 确保游戏运行期间首次启用或新增映射时可以立即生效。
-            _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process));
+            _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process, game.KeyMappings,
+                preExistingProcessIds, processRelay));
             await jumpListService.AddToJumpListAsync(game);
             messenger.Send(new GalgamePlayedMessage(game));
 
             await Task.Delay(1000);
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysEnableMagpie) || game.EnableMagpie)
-                _ = bgTaskService.AddBgTask(new CallMagpieTask(game, process));
+                _ = bgTaskService.AddBgTask(new CallMagpieTask(game, process, processRelay));
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysMuteInBackground) ||
                 game.MuteInBackground)
-                _ = bgTaskService.AddBgTask(new GameMuteTask(game, process));
+                _ = bgTaskService.AddBgTask(new GameMuteTask(game, process, processRelay));
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AutoDetectSavePath) &&
                 config.DetectedSavePath is null)
                 _ = bgTaskService.AddBgTask(new GameSaveDetectorTask(game, installation));
-            if (!process.HasExited)
+            if (GameProcessDetector.IsAlive(process))
                 App.SetWindowMode(
                     await localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode));
 
-            await process.WaitForExitAsync();
+            await WaitForGameSessionEndAsync(process, processRelay);
         }
         catch (Win32Exception e) when (e.NativeErrorCode == 1223)
         {
@@ -209,6 +223,19 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+        finally
+        {
+            launchWindowTracker?.Stop();
+        }
+    }
+
+    private static GameLaunchWindowTracker? StartLaunchWindowTracker(LocalInstallationConfig config,
+        string installationPath, IReadOnlyCollection<int> preExistingProcessIds)
+    {
+        if (!config.DelayPlayTimeUntilMainWindow) return null;
+        GameLaunchWindowTracker tracker = new();
+        tracker.Start(GameProcessDetector.GetDirectoryPrefix(installationPath), preExistingProcessIds);
+        return tracker;
     }
 
     private bool TryEnterLaunch(Guid gameId)
@@ -227,16 +254,57 @@ public sealed class GameLaunchService(
             $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
-    private static async Task<Process?> WaitForProcessStartAsync(string processName)
+    private static async Task WaitForGameSessionEndAsync(Process initialProcess,
+        GameRuntimeProcessRelay processRelay)
     {
+        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess);
+        Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
+        Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
+        if (completed == initialProcessExit)
+        {
+            await initialProcessExit;
+            return;
+        }
+
+        Process? gameplayProcess = await gameplayProcessConfirmation;
+        if (gameplayProcess is null) return;
+        if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
+        {
+            await initialProcessExit;
+            return;
+        }
+        await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
+    }
+
+    private static async Task<Process?> WaitForProcessStartAsync(string processName,
+        IReadOnlyCollection<int>? excludedProcessIds = null)
+    {
+        HashSet<int> excluded = excludedProcessIds is null ? [] : new HashSet<int>(excludedProcessIds);
+        string normalizedProcessName = Path.GetFileNameWithoutExtension(processName);
         DateTime deadline = DateTime.UtcNow + ProcessWaitTimeout;
         do
         {
-            Process? process = Process.GetProcessesByName(processName).FirstOrDefault();
+            Process? process = Process.GetProcessesByName(normalizedProcessName)
+                .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
             if (process is not null) return process;
             await Task.Delay(250);
         } while (DateTime.UtcNow < deadline);
         return null;
+    }
+
+    private static bool ProcessMatchesConfiguredName(Process process, string configuredProcessName)
+    {
+        try
+        {
+            return string.Equals(
+                process.ProcessName,
+                Path.GetFileNameWithoutExtension(configuredProcessName),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static async Task<bool> SelectProcessAsync(LocalInstallationConfig config)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -257,23 +257,42 @@ public sealed class GameLaunchService(
     private static async Task WaitForGameSessionEndAsync(Process initialProcess,
         GameRuntimeProcessRelay processRelay)
     {
-        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess);
-        Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
-        Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
-        if (completed == initialProcessExit)
+        using CancellationTokenSource initialProcessExitCancellation = new();
+        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess,
+            initialProcessExitCancellation.Token);
+        try
         {
-            await initialProcessExit;
-            return;
-        }
+            Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
+            Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
+            if (completed == initialProcessExit)
+            {
+                await initialProcessExit;
+                return;
+            }
 
-        Process? gameplayProcess = await gameplayProcessConfirmation;
-        if (gameplayProcess is null) return;
-        if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
-        {
-            await initialProcessExit;
-            return;
+            Process? gameplayProcess = await gameplayProcessConfirmation;
+            if (gameplayProcess is null) return;
+            if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
+            {
+                await initialProcessExit;
+                return;
+            }
+
+            initialProcessExitCancellation.Cancel();
+            await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
         }
-        await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
+        finally
+        {
+            initialProcessExitCancellation.Cancel();
+            try
+            {
+                await initialProcessExit;
+            }
+            catch (OperationCanceledException) when (initialProcessExitCancellation.IsCancellationRequested)
+            {
+                // 进程接力后不再等待启动器退出，但仍观察已取消的等待任务。
+            }
+        }
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName,
@@ -284,9 +303,19 @@ public sealed class GameLaunchService(
         DateTime deadline = DateTime.UtcNow + ProcessWaitTimeout;
         do
         {
-            Process? process = Process.GetProcessesByName(normalizedProcessName)
-                .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
-            if (process is not null) return process;
+            Process[] candidates = Process.GetProcessesByName(normalizedProcessName);
+            Process? selected = null;
+            try
+            {
+                selected = candidates
+                    .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
+                if (selected is not null) return selected;
+            }
+            finally
+            {
+                foreach (Process candidate in candidates)
+                    if (!ReferenceEquals(candidate, selected)) candidate.Dispose();
+            }
             await Task.Delay(250);
         } while (DateTime.UtcNow < deadline);
         return null;

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -26,6 +26,8 @@ public sealed class GameLaunchService(
     : IGameLaunchService
 {
     private static readonly TimeSpan ProcessWaitTimeout = TimeSpan.FromSeconds(60); // 等待目标游戏进程出现的最长时间
+    private readonly object _launchStateLock = new();
+    private readonly HashSet<Guid> _launchesInProgress = [];
     private readonly GalgameCollectionService _gameService =
         (GalgameCollectionService)gameCollectionService; // 逻辑游戏持久化与可执行文件选择服务
 
@@ -34,6 +36,35 @@ public sealed class GameLaunchService(
     {
         if (installation.Galgame != game || !installation.IsLocalInstallation)
             throw new ArgumentException("The installation does not belong to the game.", nameof(installation));
+
+        if (!TryEnterLaunch(game.Uuid))
+        {
+            ReportDuplicateLaunch(game, "launch request already in progress");
+            return;
+        }
+
+        try
+        {
+            await LaunchCoreAsync(game, installation);
+        }
+        finally
+        {
+            lock (_launchStateLock)
+            {
+                _launchesInProgress.Remove(game.Uuid);
+            }
+        }
+    }
+
+    private async Task LaunchCoreAsync(Galgame game, GalgameAndPath installation)
+    {
+        string gameKey = game.Uuid.ToString("D");
+        if (bgTaskService.GetBgTask<RecordPlayTimeTask>(gameKey) is not null)
+        {
+            ReportDuplicateLaunch(game, "play-time task already active");
+            return;
+        }
+
         if (!Directory.Exists(installation.Path))
         {
             infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
@@ -178,6 +209,22 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+    }
+
+    private bool TryEnterLaunch(Guid gameId)
+    {
+        lock (_launchStateLock)
+        {
+            return _launchesInProgress.Add(gameId);
+        }
+    }
+
+    private void ReportDuplicateLaunch(Galgame game, string reason)
+    {
+        infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            msg: "GalgamePage_Play_AlreadyRunning".GetLocalized(game.Name.Value ?? string.Empty));
+        infoService.Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName)

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4150,4 +4150,13 @@ If play time can record correctly, just cancel this popup.
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>“{0}” is already running or its play time is being recorded.</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>Waiting for the game window: {0} (launch dialogs are not counted)</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>Do not count launch dialogs</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>For installations that first show a disclaimer, patch notice, or launcher. Recording starts after a stable window transition; leave this off for games that open directly.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4147,4 +4147,7 @@ If play time can record correctly, just cancel this popup.
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>No target library available. Add another library first.</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}” is already running or its play time is being recorded.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4079,4 +4079,13 @@
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>ゲーム画面を待機中: {0}（起動時のダイアログは記録しません）</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>起動ダイアログをプレイ時間に含めない</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>最初に免責事項、パッチ案内、ランチャーを表示するインストール向けです。安定したウィンドウ切り替え後に記録を開始します。直接ゲームを開く場合はオフのままにしてください。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4076,4 +4076,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>移動先のライブラリがありません。先に別のライブラリを追加してください。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5059,4 +5059,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>没有可移动到的目标库，请先添加另一个库。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}”已在运行或正在记录游玩时间。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5062,4 +5062,13 @@
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>“{0}”已在运行或正在记录游玩时间。</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>正在等待游戏主窗口：{0}（声明或启动器窗口期间暂不计时）</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>启动弹窗期间暂不计时</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>适用于先显示声明、补丁说明或启动器的安装实例。开启后会等到窗口发生稳定切换再开始计时；直接进入游戏的实例请保持关闭。</value>
+  </data>
 </root>

--- a/GalgameManager/Views/GalgameSettingPage.xaml
+++ b/GalgameManager/Views/GalgameSettingPage.xaml
@@ -177,6 +177,14 @@
                                              ToolTipService.ToolTip="就把他当成cmd来用就行了" />
                                 </Grid>
                             </control:Panel>
+                            <!-- 启动弹窗期间暂不计时 -->
+                            <control:Panel Visibility="{x:Bind ViewModel.IsLocalGame, Mode=OneWay}">
+                                <control:Setting x:Uid="GalgameSettingPage_DelayPlayTimeUntilMainWindow">
+                                    <ToggleSwitch
+                                        IsOn="{x:Bind ViewModel.SelectedInstallationConfig.DelayPlayTimeUntilMainWindow,
+                                        Mode=TwoWay, FallbackValue=False}" />
+                                </control:Setting>
+                            </control:Panel>
                             <!-- 后台时静音游戏 -->
                             <control:Panel>
                                 <Grid ColumnDefinitions="Auto,*,Auto">


### PR DESCRIPTION
> 依赖 #718；#719 已合并。当前本地分支基于 #718 的最新提交 `027288c` 整理，待 #718 合并后差异会自动收敛为本 PR 的进程接力改动。

#709 提到的退出通知延迟，来自游戏进程结束后的 5 秒替代进程检查。这个检查用于兼容启动器或汉化程序先退出、实际游戏随后启动的情况，但此前无法判断退出的是启动器还是真正的游戏，所以正常退出游戏也会等待完整倒计时。

这次保留启动阶段的接力检查，同时在运行过程中确认实际游戏进程：

- 启动前记录安装目录中已有的进程，只把本次启动后出现的进程作为接力候选，避免附着到之前残留的同目录进程。
- 当安装目录内另一个进程连续处于前台时，计时任务会接替到该进程；适用于汉化启动器拉起不同 exe，以及启动器和原版 exe 同时存在的情况。
- 游戏窗口稳定后会确认实际游戏 PID。这个 PID 退出时，计时和按键映射任务立即结束，不再继续等待 5 秒；尚未确认实际游戏 PID 时仍保留原来的短暂检查。
- 计时任务确认实际游戏进程后，会把结果同步给静音、Magpie 和按键映射任务，使它们在进程接力后也切换到同一个目标。
- 受保护或管理员进程拒绝 `Process.HasExited`、`WaitForExitAsync` 等查询时，改用 PID 快照判断存活和退出，不再直接把“拒绝访问”当成游戏结束。

游戏设置中新增了按安装实例保存的“启动弹窗期间暂不计时”选项。它适用于先显示声明、补丁说明或启动器的游戏：开启后会从实际启动游戏之前持续记录安装目录中新进程的窗口转换历史，并按“确认启动窗口、等待窗口切换、确认正式游戏窗口”三个阶段判断。即使用户在后台任务附着前快速关闭声明，任务也能沿用已有历史确认随后出现的正式窗口。只有进程、窗口句柄或窗口类等窗口身份发生真实切换后才开始计时和确认游戏 PID。同一窗口改标题、调整大小、短暂隐藏后重新出现都不会被误判为正式游戏。直接进入游戏的安装实例保持关闭即可。

如果用户在启动弹窗阶段主动取消，任务仍会等待最多 5 秒，因为此时还不能确定是已经取消，还是启动器即将拉起另一个游戏进程。进入并退出真正的游戏后则会立即结束。


## 验证

补充了启动前窗口历史、窗口切换门控、稳定进程接力、正式 PID 退出策略、进程共享和安装配置复制测试。三语言资源工具校验通过，x64 Release 构建正常。

测试中覆盖了普通直启游戏、先显示声明弹窗的游戏（おばさんじゃない、女だったAI翻译版）、短命汉化启动器拉起不同 exe 的游戏（9-nine-ここのつここのかここのいろ汉化版），以及汉化外壳与原版 exe 同时存活的游戏（恋がさくころ桜どき汉化版）。四种进程生命周期均能正常计时，并在进入游戏后立即响应实际游戏进程退出；共存进程场景还验证了静音、Magpie 和按键映射会作用于前台的原版游戏进程。声明弹窗场景分别验证了停留不计时、关闭弹窗后以 0 秒结束，以及快速确认后进入正式游戏并开始计时。

值得说明的是，目前受保护／管理员游戏的权限边界仍缺少稳定复现环境；当前只通过自动测试验证拒绝进程状态查询时会改用 PID 快照，而不会误判为游戏退出。