### PR TITLE
feat: 原生记录并编辑逐次游玩时段

### DIFF
--- a/GalgameManager.Test/Helpers/GameProcessDetectorTest.cs
+++ b/GalgameManager.Test/Helpers/GameProcessDetectorTest.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameProcessDetectorTest
+{
+    [Test]
+    public void IsProcessIdPresent_FindsCurrentProcessWithoutQueryingTargetState()
+    {
+        using Process current = Process.GetCurrentProcess();
+
+        Assert.That(GameProcessDetector.IsProcessIdPresent(current.Id), Is.True);
+    }
+
+    [Test]
+    public void IsProcessIdPresent_RejectsInvalidIds()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameProcessDetector.IsProcessIdPresent(0), Is.False);
+            Assert.That(GameProcessDetector.IsProcessIdPresent(-1), Is.False);
+        });
+    }
+
+    [Test]
+    public void WaitForExitSafelyAsync_StillHonorsCancellationForRunningProcess()
+    {
+        using Process current = Process.GetCurrentProcess();
+        using CancellationTokenSource cancellation = new(TimeSpan.FromMilliseconds(100));
+
+        Assert.That(async () => await GameProcessDetector.WaitForExitSafelyAsync(current, cancellation.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+    }
+}

--- a/GalgameManager.Test/Helpers/GameRuntimeProcessRelayTest.cs
+++ b/GalgameManager.Test/Helpers/GameRuntimeProcessRelayTest.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameRuntimeProcessRelayTest
+{
+    [Test]
+    public async Task Confirm_PublishesConfirmedProcess()
+    {
+        GameRuntimeProcessRelay relay = new();
+        using Process process = Process.GetCurrentProcess();
+
+        relay.Confirm(process);
+        Process? confirmed = await relay.WaitForConfirmationAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(confirmed, Is.SameAs(process));
+            Assert.That(relay.ConfirmedProcess, Is.SameAs(process));
+            Assert.That(relay.IsCompleted, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task CompleteWithoutConfirmation_ReleasesWaiterWithNull()
+    {
+        GameRuntimeProcessRelay relay = new();
+        Task<Process?> waiter = relay.WaitForConfirmationAsync();
+
+        relay.Complete();
+        Process? result = await waiter;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.Null);
+            Assert.That(relay.IsCompleted, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task ConfirmAfterCompletion_DoesNotPublishProcess()
+    {
+        GameRuntimeProcessRelay relay = new();
+        using Process process = Process.GetCurrentProcess();
+        relay.Complete();
+
+        relay.Confirm(process);
+
+        Assert.That(await relay.WaitForConfirmationAsync(), Is.Null);
+        Assert.That(relay.ConfirmedProcess, Is.Null);
+    }
+}

--- a/GalgameManager.Test/Helpers/GameWindowTransitionGateTest.cs
+++ b/GalgameManager.Test/Helpers/GameWindowTransitionGateTest.cs
@@ -1,0 +1,314 @@
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class GameWindowTransitionGateTest
+{
+    [Test]
+    public void Observe_UnchangedLaunchDialog_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+            Assert.That(gate.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+        });
+    }
+
+    [Test]
+    public void Observe_LaunchDialogLayoutChanges_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot opening = Snapshot(100, 10, "Dialog", "", 360, 240);
+        GameWindowSnapshot ready = Snapshot(100, 10, "Dialog", "Disclaimer", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(opening), Is.False);
+            Assert.That(gate.Observe(ready), Is.False);
+            Assert.That(gate.Observe(ready), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+        });
+    }
+
+    [Test]
+    public void Observe_FirstWindowBelongsToReplacementProcess_RemainsPendingUntilWindowChanges()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot replacementDialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "TVPMainWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.Observe(replacementDialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+            Assert.That(gate.Observe(game), Is.False);
+            Assert.That(gate.Observe(game), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_NewWindowMustRemainStableBeforeRecordingStarts()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+        GameWindowSnapshot game = Snapshot(100, 20, "GameWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(game), Is.False);
+            Assert.That(gate.Observe(game), Is.True);
+            Assert.That(gate.IsReady, Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_TransientWindowThenDialogAgain_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot dialog = Snapshot(100, 10, "Dialog", "Disclaimer", 480, 360);
+        GameWindowSnapshot transient = Snapshot(100, 30, "Tooltip", "", 200, 100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.Observe(transient), Is.False);
+            Assert.That(gate.Observe(dialog), Is.False);
+            Assert.That(gate.IsReady, Is.False);
+        });
+    }
+
+    [Test]
+    public void Observe_LauncherHandsOffToNewProcess_StartsAfterStableSample()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot launcher = Snapshot(100, 10, "Launcher", "Launcher", 600, 400);
+        GameWindowSnapshot game = Snapshot(200, 40, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(gate.Observe(launcher), Is.False);
+        Assert.That(gate.Observe(launcher), Is.False);
+        Assert.That(gate.Observe(game), Is.False);
+        Assert.That(gate.Observe(game), Is.True);
+    }
+
+    [Test]
+    public void HasMeaningfulTransition_SameWindowTitleOrSizeChangeIsIgnored()
+    {
+        GameWindowSnapshot baseline = Snapshot(100, 10, "Game", "Launcher", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "Game", "Actual game", 640, 480)), Is.False);
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "Game", "Launcher", 1280, 720)), Is.False);
+            Assert.That(GameWindowTransitionGate.HasMeaningfulTransition(baseline,
+                Snapshot(100, 10, "GameWindow", "Launcher", 640, 480)), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_WindowDisappearsThenSameIdentityReturns_RemainsPending()
+    {
+        GameWindowTransitionGate gate = new();
+        GameWindowSnapshot window = Snapshot(100, 10, "Game", "Launcher", 640, 480);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(null), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+        });
+    }
+
+    [Test]
+    public void Observe_FastConfirmationHistory_ReachesReadyBeforeConsumerStarts()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "TVPMainWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Observe(dialog), Is.False);
+            Assert.That(tracker.Observe(dialog), Is.False);
+            Assert.That(tracker.Observe(game), Is.False);
+            Assert.That(tracker.Observe(game), Is.True);
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.Ready));
+            Assert.That(tracker.ConfirmedSnapshot, Is.EqualTo(game));
+        });
+
+        Assert.That(tracker.DrainLogSnapshots(), Is.EqualTo(new[] { dialog, game }));
+    }
+
+    [Test]
+    public void Observe_NoPopupSingleWindow_RemainsBaselineWhenWaitingWasExplicitlyEnabled()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot game = Snapshot(200, 30, "GameWindow", "Game", 1280, 720);
+
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(game), Is.False);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+            Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Observe_ReplacementDialogWithoutTransition_RemainsPending()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot replacementDialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(replacementDialog), Is.False);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tracker.Stage, Is.EqualTo(GameWindowTransitionStage.WaitingForTransition));
+            Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Observe_RejectedDialogDoesNotConfirmGameplayWindow()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        for (int i = 0; i < 10; i++) Assert.That(tracker.Observe(null), Is.False);
+
+        Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+    }
+
+    [Test]
+    public void Observe_ReplacementProcessGameWindow_UsesCompleteLaunchHistory()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(300, 30, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(game), Is.False);
+        Assert.That(tracker.Observe(game), Is.True);
+
+        Assert.That(tracker.ConfirmedSnapshot?.ProcessId, Is.EqualTo(300));
+    }
+
+    [Test]
+    public void Observe_LauncherThenStandardDialog_WaitsForFollowingGameWindow()
+    {
+        GameLaunchWindowTracker tracker = new();
+        GameWindowSnapshot launcher = Snapshot(100, 10, "LauncherWindow", "Launcher", 640, 480);
+        GameWindowSnapshot dialog = Snapshot(200, 20, "#32770", "Disclaimer", 417, 235);
+        GameWindowSnapshot game = Snapshot(200, 30, "GameWindow", "Game", 1280, 720);
+
+        Assert.That(tracker.Observe(launcher), Is.False);
+        Assert.That(tracker.Observe(launcher), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.Observe(dialog), Is.False);
+        Assert.That(tracker.ConfirmedSnapshot, Is.Null);
+        Assert.That(tracker.Observe(game), Is.False);
+        Assert.That(tracker.Observe(game), Is.True);
+
+        Assert.That(tracker.ConfirmedSnapshot, Is.EqualTo(game));
+    }
+
+    [Test]
+    public void StableProcessHandoffGate_RequiresTwoSamplesFromSameDifferentProcess()
+    {
+        StableProcessHandoffGate gate = new();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(100, 100), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, 300), Is.False);
+            Assert.That(gate.Observe(100, 300), Is.True);
+        });
+    }
+
+    [Test]
+    public void StableProcessHandoffGate_MissingForegroundProcessResetsCandidate()
+    {
+        StableProcessHandoffGate gate = new();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, null), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.False);
+            Assert.That(gate.Observe(100, 200), Is.True);
+        });
+    }
+
+    private static GameWindowSnapshot Snapshot(int processId, nint windowHandle, string className, string title,
+        int width, int height) => new(processId, windowHandle, className, title, width, height);
+}
+
+[TestFixture]
+public class StableGameWindowGateTest
+{
+    [Test]
+    public void Observe_RequiresTwoStableUsableSamples()
+    {
+        StableGameWindowGate gate = new();
+        GameWindowSnapshot window = new(42, (nint)123, "GameWindow", "Game", 1280, 720);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(window), Is.False);
+            Assert.That(gate.Observe(window), Is.True);
+        });
+    }
+
+    [Test]
+    public void Observe_ResetsWhenWindowChanges()
+    {
+        StableGameWindowGate gate = new();
+        GameWindowSnapshot first = new(42, (nint)123, "GameWindow", "Game", 1280, 720);
+        GameWindowSnapshot second = first with { WindowHandle = (nint)456 };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(gate.Observe(first), Is.False);
+            Assert.That(gate.Observe(second), Is.False);
+            Assert.That(gate.Observe(second), Is.True);
+        });
+    }
+}
+
+[TestFixture]
+public class GameSessionExitPolicyTest
+{
+    [TestCase(false, 0, 42, true)]
+    [TestCase(true, 0, 42, true)]
+    [TestCase(true, 99, 42, true)]
+    [TestCase(true, 42, 42, false)]
+    public void ShouldWaitForReplacement_OnlySkipsConfirmedGameplayPid(
+        bool recordingStarted,
+        int confirmedPid,
+        int exitedPid,
+        bool expected)
+    {
+        Assert.That(GameSessionExitPolicy.ShouldWaitForReplacement(recordingStarted, confirmedPid, exitedPid),
+            Is.EqualTo(expected));
+    }
+}

--- a/GalgameManager.Test/Helpers/PlayTimeRecordingModeHelperTest.cs
+++ b/GalgameManager.Test/Helpers/PlayTimeRecordingModeHelperTest.cs
@@ -1,0 +1,26 @@
+using GalgameManager.Helpers;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class PlayTimeRecordingModeHelperTest
+{
+    [TestCase(false, true, true, false)]
+    [TestCase(true, false, false, true)]
+    [TestCase(null, true, false, true)]
+    [TestCase(null, false, true, true)]
+    [TestCase(null, false, false, false)]
+    public void ResolvePreciseMode_KeepsLockedOrRecoveredLaunchMode(
+        bool? lockedMode,
+        bool hasActiveSession,
+        bool settingEnabled,
+        bool expected)
+    {
+        Assert.That(
+            PlayTimeRecordingModeHelper.ResolvePreciseMode(
+                lockedMode,
+                hasActiveSession,
+                settingEnabled),
+            Is.EqualTo(expected));
+    }
+}

--- a/GalgameManager.Test/Helpers/PlayTimeSessionHelperTest.cs
+++ b/GalgameManager.Test/Helpers/PlayTimeSessionHelperTest.cs
@@ -1,0 +1,856 @@
+using GalgameManager.Helpers;
+using GalgameManager.Core.Helpers;
+using GalgameManager.Models;
+using GalgameManager.Views.Dialog;
+using Newtonsoft.Json;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class PlayTimeSessionHelperTest
+{
+    [Test]
+    public void AddLegacyMinuteSample_SeedsLegacyDataWithoutCreatingSession()
+    {
+        DateTime lastPlayTime = new(2026, 8, 20, 18, 30, 0);
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/19"] = 2 },
+            TotalPlayTime = 2,
+            LastPlayTime = lastPlayTime,
+        };
+
+        PlayTimeSessionHelper.AddLegacyMinuteSample(game, new DateTime(2026, 8, 19, 20, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(180));
+            Assert.That(game.PlayedTime["2026/8/19"], Is.EqualTo(3));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(3));
+            Assert.That(game.LastPlayTime, Is.EqualTo(lastPlayTime));
+            Assert.That(game.PlayTimeSessions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void AddLegacyMinuteSample_PreservesExistingSecondRemainderAndSessions()
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = new DateTime(2026, 8, 19, 12, 0, 0),
+            EndedAt = new DateTime(2026, 8, 19, 12, 0, 31),
+        };
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/19"] = 2 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/19"] = 151 },
+            PlayTimeSessions = [session],
+            TotalPlayTime = 2,
+        };
+
+        PlayTimeSessionHelper.AddLegacyMinuteSample(game, new DateTime(2026, 8, 19, 20, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(211));
+            Assert.That(game.PlayedTime["2026/8/19"], Is.EqualTo(3));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(3));
+            Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(1));
+            Assert.That(game.PlayTimeSessions[0].Id, Is.EqualTo(session.Id));
+        });
+    }
+
+    [Test]
+    public void DisplayPlayTime_MinuteModePreservesHiddenSecondRemainder()
+    {
+        DisplayPlayTime time = new("2026/8/19", 151, 0, false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(time.PlayedTime, Is.EqualTo(2));
+            Assert.That(time.SecondsVisibility, Is.EqualTo(Microsoft.UI.Xaml.Visibility.Collapsed));
+            Assert.That(time.TotalSeconds, Is.EqualTo(151));
+        });
+
+        time.PlayedTime = 3;
+        Assert.That(time.TotalSeconds, Is.EqualTo(211));
+    }
+
+    [Test]
+    public void AddInterval_SeedsLegacyMinutesAndKeepsSecondPrecision()
+    {
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/19"] = 2 },
+            TotalPlayTime = 2,
+        };
+
+        PlayTimeSessionHelper.AddInterval(
+            game,
+            new DateTime(2026, 8, 19, 12, 0, 0),
+            new DateTime(2026, 8, 19, 12, 0, 31));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(151));
+            Assert.That(game.PlayedTime["2026/8/19"], Is.EqualTo(2));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void AddInterval_SplitsAtMidnight()
+    {
+        Galgame game = new();
+
+        PlayTimeSessionHelper.AddInterval(
+            game,
+            new DateTime(2026, 8, 19, 23, 59, 45),
+            new DateTime(2026, 8, 20, 0, 0, 15));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(15));
+            Assert.That(game.PlayedTimeSeconds["2026/8/20"], Is.EqualTo(15));
+            Assert.That(game.PlayedTime, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ExtendSession_UsesWholeSessionBoundaryWithoutSamplingDrift()
+    {
+        DateTime start = new(2026, 8, 21, 1, 1, 20);
+        PlayTimeSession session = new()
+        {
+            StartedAt = start,
+            EndedAt = start,
+            IsOpen = true,
+            ActivityIntervals = [],
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+        PlayTimeActivityInterval interval = PlayTimeSessionHelper.BeginActivityInterval(session, start);
+        long countedSeconds = 0;
+
+        for (int i = 1; i <= 90; i++)
+            countedSeconds += PlayTimeSessionHelper.ExtendActivityInterval(
+                game,
+                session,
+                interval,
+                start.AddMilliseconds(i * 1490));
+
+        long sessionSeconds = PlayTimeSessionHelper.SplitSessionByDay(session)
+            .Sum(segment => segment.DurationSeconds);
+        Assert.Multiple(() =>
+        {
+            Assert.That(countedSeconds, Is.EqualTo(134));
+            Assert.That(game.PlayedTimeSeconds["2026/8/21"], Is.EqualTo(sessionSeconds));
+            Assert.That(sessionSeconds, Is.EqualTo(134));
+        });
+    }
+
+    [Test]
+    public void ExtendSession_KeepsCrossMidnightDailyTotalsAligned()
+    {
+        DateTime start = new(2026, 8, 21, 23, 59, 58, 600);
+        PlayTimeSession session = new()
+        {
+            StartedAt = start,
+            EndedAt = start,
+            IsOpen = true,
+            ActivityIntervals = [],
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+        PlayTimeActivityInterval interval = PlayTimeSessionHelper.BeginActivityInterval(session, start);
+
+        PlayTimeSessionHelper.ExtendActivityInterval(game, session, interval, start.AddSeconds(3.2));
+
+        PlayTimeDaySegment[] segments = PlayTimeSessionHelper.SplitSessionByDay(session).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/21"], Is.EqualTo(1));
+            Assert.That(game.PlayedTimeSeconds["2026/8/22"], Is.EqualTo(2));
+            Assert.That(game.PlayedTimeSeconds.Values.Sum(), Is.EqualTo(segments.Sum(x => x.DurationSeconds)));
+        });
+    }
+
+    [Test]
+    public void ActivityIntervals_GroupForegroundFragmentsIntoOneLaunchSession()
+    {
+        DateTime start = new(2026, 8, 22, 10, 0, 0);
+        PlayTimeSession session = new()
+        {
+            StartedAt = start,
+            EndedAt = start,
+            IsOpen = true,
+            ActivityIntervals = [],
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+
+        PlayTimeActivityInterval first = PlayTimeSessionHelper.BeginActivityInterval(session, start);
+        PlayTimeSessionHelper.ExtendActivityInterval(game, session, first, start.AddMinutes(2));
+        PlayTimeActivityInterval second = PlayTimeSessionHelper.BeginActivityInterval(session, start.AddMinutes(5));
+        PlayTimeSessionHelper.ExtendActivityInterval(game, session, second, start.AddMinutes(7));
+        session.EndedAt = start.AddMinutes(10);
+
+        PlayTimeDaySegment[] segments = PlayTimeSessionHelper.SplitSessionByDay(session).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.ActivityIntervals, Has.Count.EqualTo(2));
+            Assert.That(segments, Has.Length.EqualTo(1));
+            Assert.That(segments[0].StartedAt, Is.EqualTo(start));
+            Assert.That(segments[0].EndedAt, Is.EqualTo(start.AddMinutes(10)));
+            Assert.That(segments[0].DurationSeconds, Is.EqualTo(240));
+            Assert.That(game.PlayedTimeSeconds["2026/8/22"], Is.EqualTo(240));
+            Assert.That(PlayTimeSessionHelper.GetSessionDurationSeconds(session), Is.EqualTo(240));
+        });
+    }
+
+    [Test]
+    public void GetActivityIntervalsForDay_ReturnsOnlyClippedForegroundFragments()
+    {
+        DateTime firstDay = new(2026, 8, 22, 23, 58, 0);
+        PlayTimeSession session = new()
+        {
+            StartedAt = firstDay,
+            EndedAt = firstDay.AddMinutes(12),
+            ActivityIntervals =
+            [
+                new PlayTimeActivityInterval
+                {
+                    StartedAt = firstDay,
+                    EndedAt = firstDay.AddMinutes(4),
+                },
+                new PlayTimeActivityInterval
+                {
+                    StartedAt = firstDay.AddMinutes(7),
+                    EndedAt = firstDay.AddMinutes(10),
+                },
+            ],
+        };
+
+        PlayTimeActivityInterval[] firstDayIntervals =
+            PlayTimeSessionHelper.GetActivityIntervalsForDay(session, firstDay).ToArray();
+        PlayTimeActivityInterval[] secondDayIntervals =
+            PlayTimeSessionHelper.GetActivityIntervalsForDay(session, firstDay.AddDays(1)).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstDayIntervals, Has.Length.EqualTo(1));
+            Assert.That(firstDayIntervals[0].StartedAt, Is.EqualTo(firstDay));
+            Assert.That(firstDayIntervals[0].EndedAt, Is.EqualTo(firstDay.Date.AddDays(1)));
+            Assert.That(secondDayIntervals, Has.Length.EqualTo(2));
+            Assert.That(secondDayIntervals[0].StartedAt, Is.EqualTo(firstDay.Date.AddDays(1)));
+            Assert.That(secondDayIntervals[0].EndedAt, Is.EqualTo(firstDay.AddMinutes(4)));
+            Assert.That(secondDayIntervals[1].StartedAt, Is.EqualTo(firstDay.AddMinutes(7)));
+        });
+    }
+
+    [Test]
+    public void AddManualSession_UpdatesExactAndLegacyTotals()
+    {
+        DateTime start = new(2026, 8, 22, 12, 0, 10);
+        PlayTimeSession session = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddSeconds(75),
+            Kind = PlayTimeSessionKind.Manual,
+            ActivityIntervals =
+            [
+                new PlayTimeActivityInterval { StartedAt = start, EndedAt = start.AddSeconds(75) },
+            ],
+        };
+        Galgame game = new();
+
+        PlayTimeSessionHelper.AddSession(game, session);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(1));
+            Assert.That(game.PlayedTimeSeconds["2026/8/22"], Is.EqualTo(75));
+            Assert.That(game.PlayedTime["2026/8/22"], Is.EqualTo(1));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AddSession_RejectsOverlapButAllowsTouchingBoundary()
+    {
+        DateTime start = new(2026, 8, 23, 10, 0, 0);
+        PlayTimeSession existing = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddHours(1),
+        };
+        PlayTimeSession overlapping = new()
+        {
+            StartedAt = start.AddMinutes(30),
+            EndedAt = start.AddHours(2),
+            Kind = PlayTimeSessionKind.Manual,
+        };
+        PlayTimeSession touching = new()
+        {
+            StartedAt = existing.EndedAt,
+            EndedAt = existing.EndedAt.AddMinutes(30),
+            Kind = PlayTimeSessionKind.Manual,
+        };
+        Galgame game = new() { PlayTimeSessions = [existing] };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PlayTimeSessionHelper.HasOverlappingSession(game, overlapping), Is.True);
+            Assert.That(PlayTimeSessionHelper.HasOverlappingSession(game, touching), Is.False);
+            Assert.Throws<InvalidOperationException>(() =>
+                PlayTimeSessionHelper.AddSession(game, overlapping));
+            Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(1));
+        });
+
+        PlayTimeSessionHelper.AddSession(game, touching);
+        Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void ReplaceSession_RejectsOverlapWithoutChangingExistingTotals()
+    {
+        DateTime start = new(2026, 8, 23, 10, 0, 0);
+        PlayTimeSession first = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddMinutes(30),
+        };
+        PlayTimeSession second = new()
+        {
+            StartedAt = start.AddHours(1),
+            EndedAt = start.AddHours(2),
+        };
+        Galgame game = new() { PlayTimeSessions = [first, second] };
+        PlayTimeSessionHelper.AddInterval(game, first.StartedAt, first.EndedAt);
+        PlayTimeSessionHelper.AddInterval(game, second.StartedAt, second.EndedAt);
+        long originalSeconds = game.PlayedTimeSeconds["2026/8/23"];
+        PlayTimeSession replacement = first.Clone();
+        replacement.EndedAt = start.AddHours(1.5);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            PlayTimeSessionHelper.ReplaceSession(game, first, replacement));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayTimeSessions[0].EndedAt, Is.EqualTo(first.EndedAt));
+            Assert.That(game.PlayedTimeSeconds["2026/8/23"], Is.EqualTo(originalSeconds));
+        });
+    }
+
+    [Test]
+    public void ReconcileCountedSessionTotals_RepairsAggregateShorterThanCountedSessions()
+    {
+        DateTime start = new(2026, 8, 21, 1, 1, 20);
+        PlayTimeSession session = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddSeconds(5480),
+        };
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/21"] = 90 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/21"] = 5423 },
+            PlayTimeSessions = [session],
+            TotalPlayTime = 90,
+        };
+
+        bool changed = PlayTimeSessionHelper.ReconcileCountedSessionTotals(game);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(game.PlayedTimeSeconds["2026/8/21"], Is.EqualTo(5480));
+            Assert.That(game.PlayedTime["2026/8/21"], Is.EqualTo(91));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(91));
+        });
+    }
+
+    [Test]
+    public void ReplaceAndDeleteSession_AdjustPreciseAndLegacyTotals()
+    {
+        DateTime start = new(2026, 8, 19, 20, 0, 0);
+        PlayTimeSession original = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddSeconds(90),
+        };
+        Galgame game = new() { PlayTimeSessions = [original] };
+        PlayTimeSessionHelper.AddInterval(game, original.StartedAt, original.EndedAt);
+
+        PlayTimeSession replacement = original.Clone();
+        replacement.EndedAt = start.AddSeconds(150);
+        PlayTimeSessionHelper.ReplaceSession(game, original, replacement);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(150));
+            Assert.That(game.PlayedTime["2026/8/19"], Is.EqualTo(2));
+        });
+
+        Assert.That(PlayTimeSessionHelper.DeleteSession(game, original.Id), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayTimeSessions, Is.Empty);
+            Assert.That(game.PlayedTimeSeconds, Is.Empty);
+            Assert.That(game.PlayedTime, Is.Empty);
+            Assert.That(game.TotalPlayTime, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ReplaceSession_MissingOriginalDoesNotChangeTotals()
+    {
+        DateTime start = new(2026, 8, 19, 20, 0, 0);
+        PlayTimeSession missing = new()
+        {
+            StartedAt = start,
+            EndedAt = start.AddSeconds(90),
+        };
+        PlayTimeSession replacement = missing.Clone();
+        replacement.EndedAt = start.AddSeconds(150);
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/19"] = 2 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/19"] = 120 },
+            TotalPlayTime = 2,
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            PlayTimeSessionHelper.ReplaceSession(game, missing, replacement));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(120));
+            Assert.That(game.PlayedTime["2026/8/19"], Is.EqualTo(2));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(2));
+            Assert.That(game.PlayTimeSessions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void DeleteSession_RejectsOpenSession()
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = new DateTime(2026, 8, 19, 20, 0, 0),
+            EndedAt = new DateTime(2026, 8, 19, 20, 1, 0),
+            IsOpen = true,
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+
+        Assert.That(PlayTimeSessionHelper.DeleteSession(game, session.Id), Is.False);
+    }
+
+    [Test]
+    public void AddLegacyMinuteSample_TracksMinuteSegmentsWithoutChangingSamplingPrecision()
+    {
+        DateTime firstDate = new(2026, 8, 23, 23, 59, 30);
+        DateTime secondDate = firstDate.AddMinutes(1);
+        PlayTimeSession session = new()
+        {
+            StartedAt = firstDate.AddMinutes(-1),
+            EndedAt = firstDate.AddMinutes(-1),
+            IsOpen = true,
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+
+        PlayTimeSessionHelper.AddLegacyMinuteSample(game, firstDate, session);
+        PlayTimeSessionHelper.AddLegacyMinuteSample(game, secondDate, session);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTime["2026/8/23"], Is.EqualTo(1));
+            Assert.That(game.PlayedTime["2026/8/24"], Is.EqualTo(1));
+            Assert.That(game.PlayedTimeSeconds["2026/8/23"], Is.EqualTo(60));
+            Assert.That(game.PlayedTimeSeconds["2026/8/24"], Is.EqualTo(60));
+            Assert.That(PlayTimeSessionHelper.GetMinuteSampleDurationsForDay(game, firstDate),
+                Is.EqualTo(new long[] { 60 }));
+            Assert.That(PlayTimeSessionHelper.GetMinuteSampleDurationsForDay(game, secondDate),
+                Is.EqualTo(new long[] { 60 }));
+        });
+    }
+
+    [Test]
+    public void MinuteSampleSegments_ExposeEachLaunchDurationAndBoundaries()
+    {
+        DateTime date = new(2026, 8, 23);
+        PlayTimeSession first = new()
+        {
+            StartedAt = date.AddHours(1),
+            EndedAt = date.AddHours(1.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 3 },
+        };
+        PlayTimeSession second = new()
+        {
+            StartedAt = date.AddHours(2),
+            EndedAt = date.AddHours(2.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 4 },
+        };
+        Galgame game = new() { PlayTimeSessions = [first, second] };
+
+        MinutePlayTimeDaySegment[] segments =
+            PlayTimeSessionHelper.GetMinuteSampleSegmentsForDay(game, date).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(segments, Has.Length.EqualTo(2));
+            Assert.That(segments[0].SessionId, Is.EqualTo(first.Id));
+            Assert.That(segments[0].StartedAt, Is.EqualTo(first.StartedAt));
+            Assert.That(segments[0].EndedAt, Is.EqualTo(first.EndedAt));
+            Assert.That(segments[0].Minutes, Is.EqualTo(3));
+            Assert.That(segments[0].SpansMultipleDays, Is.False);
+            Assert.That(segments[1].SessionId, Is.EqualTo(second.Id));
+            Assert.That(segments[1].Minutes, Is.EqualTo(4));
+            Assert.That(segments[1].SpansMultipleDays, Is.False);
+        });
+    }
+
+    [Test]
+    public void MinuteSampleSegments_MarkEverySliceOfCrossDayLaunch()
+    {
+        DateTime firstDate = new(2026, 8, 23);
+        DateTime secondDate = firstDate.AddDays(1);
+        PlayTimeSession session = new()
+        {
+            StartedAt = firstDate.AddHours(23).AddMinutes(30),
+            EndedAt = secondDate.AddMinutes(30),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int>
+            {
+                ["2026/8/23"] = 30,
+                ["2026/8/24"] = 30,
+            },
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+
+        MinutePlayTimeDaySegment firstSegment =
+            PlayTimeSessionHelper.GetMinuteSampleSegmentsForDay(game, firstDate).Single();
+        MinutePlayTimeDaySegment secondSegment =
+            PlayTimeSessionHelper.GetMinuteSampleSegmentsForDay(game, secondDate).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstSegment.SpansMultipleDays, Is.True);
+            Assert.That(secondSegment.SpansMultipleDays, Is.True);
+        });
+    }
+
+    [Test]
+    public void ReplaceMinuteSampleSegment_AdjustsOnlyTargetLaunchAndPreservesRemainder()
+    {
+        DateTime date = new(2026, 8, 23);
+        PlayTimeSession first = new()
+        {
+            StartedAt = date.AddHours(1),
+            EndedAt = date.AddHours(1.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 3 },
+        };
+        PlayTimeSession second = new()
+        {
+            StartedAt = date.AddHours(2),
+            EndedAt = date.AddHours(2.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 4 },
+        };
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/23"] = 10 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/23"] = 645 },
+            PlayTimeSessions = [first, second],
+        };
+
+        bool changed = PlayTimeSessionHelper.ReplaceMinuteSampleSegment(game, second.Id, date, 6);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(PlayTimeSessionHelper.GetMinuteSampleDurationsForDay(game, date),
+                Is.EqualTo(new long[] { 180, 360 }));
+            Assert.That(game.PlayedTimeSeconds["2026/8/23"], Is.EqualTo(765));
+            Assert.That(game.PlayedTime["2026/8/23"], Is.EqualTo(12));
+        });
+    }
+
+    [Test]
+    public void DayDisplayBreakdown_SeparatesPreciseMinuteAndUnsegmentedTime()
+    {
+        DateTime date = new(2026, 8, 23);
+        PlayTimeSession precise = new()
+        {
+            StartedAt = date.AddHours(1),
+            EndedAt = date.AddHours(1).AddMinutes(10),
+        };
+        PlayTimeSession firstMinute = new()
+        {
+            StartedAt = date.AddHours(2),
+            EndedAt = date.AddHours(2.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 20 },
+        };
+        PlayTimeSession secondMinute = new()
+        {
+            StartedAt = date.AddHours(3),
+            EndedAt = date.AddHours(3.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 10 },
+        };
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/23"] = 50 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/23"] = 3000 },
+            PlayTimeSessions = [precise, firstMinute, secondMinute],
+        };
+
+        PlayTimeDayBreakdown breakdown = PlayTimeSessionHelper.GetDayDisplayBreakdown(game, date);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(breakdown.TotalSeconds, Is.EqualTo(3000));
+            Assert.That(breakdown.PreciseSessionSeconds, Is.EqualTo(600));
+            Assert.That(breakdown.MinuteSampleSeconds, Is.EqualTo(1800));
+            Assert.That(breakdown.UnsegmentedSeconds, Is.EqualTo(600));
+        });
+    }
+
+    [Test]
+    public void PreciseSessionDaySegments_PreserveSeparateLaunchesForMinuteViewProjection()
+    {
+        DateTime date = new(2026, 8, 23);
+        Galgame game = new()
+        {
+            PlayTimeSessions =
+            [
+                new PlayTimeSession
+                {
+                    StartedAt = date.AddHours(1),
+                    EndedAt = date.AddHours(1).AddMinutes(4),
+                },
+                new PlayTimeSession
+                {
+                    StartedAt = date.AddHours(2),
+                    EndedAt = date.AddHours(2).AddMinutes(7),
+                },
+                new PlayTimeSession
+                {
+                    StartedAt = date.AddHours(3),
+                    EndedAt = date.AddHours(3).AddMinutes(10),
+                    Kind = PlayTimeSessionKind.MinuteSampled,
+                    CountsTowardPlayTime = false,
+                    SampledMinutesByDay = new Dictionary<string, int>
+                    {
+                        [date.ToStringDefault()] = 10,
+                    },
+                },
+            ],
+        };
+
+        PlayTimeDaySegment[] segments =
+            PlayTimeSessionHelper.GetPreciseSessionDaySegments(game).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(segments, Has.Length.EqualTo(2));
+            Assert.That(segments.Select(segment => segment.DurationSeconds),
+                Is.EqualTo(new long[] { 240, 420 }));
+            Assert.That(segments.Select(segment => segment.SessionId).Distinct().Count(),
+                Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void ReconcileCountedSessionTotals_PreservesMinuteSamplesAlongsidePreciseSessions()
+    {
+        DateTime date = new(2026, 8, 23);
+        PlayTimeSession precise = new()
+        {
+            StartedAt = date.AddHours(1),
+            EndedAt = date.AddHours(1).AddMinutes(2),
+        };
+        PlayTimeSession minute = new()
+        {
+            StartedAt = date.AddHours(2),
+            EndedAt = date.AddHours(2.5),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 4 },
+        };
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/23"] = 5 },
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/23"] = 300 },
+            PlayTimeSessions = [precise, minute],
+        };
+
+        bool changed = PlayTimeSessionHelper.ReconcileCountedSessionTotals(game);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changed, Is.True);
+            Assert.That(game.PlayedTimeSeconds["2026/8/23"], Is.EqualTo(360));
+            Assert.That(game.PlayedTime["2026/8/23"], Is.EqualTo(6));
+        });
+    }
+
+    [Test]
+    public void LargeTotals_SaturateInsteadOfOverflowing()
+    {
+        DateTime firstDate = new(2026, 8, 23);
+        DateTime secondDate = firstDate.AddDays(1);
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int>
+            {
+                [firstDate.ToStringDefault()] = int.MaxValue,
+                [secondDate.ToStringDefault()] = int.MaxValue,
+            },
+            PlayedTimeSeconds = new Dictionary<string, long>
+            {
+                [firstDate.ToStringDefault()] = long.MaxValue,
+                [secondDate.ToStringDefault()] = long.MaxValue,
+            },
+        };
+
+        Assert.DoesNotThrow(() => PlayTimeSessionHelper.AddInterval(
+            game,
+            firstDate.AddHours(1),
+            firstDate.AddHours(1).AddSeconds(1)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds[firstDate.ToStringDefault()], Is.EqualTo(long.MaxValue));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(int.MaxValue));
+            Assert.That(PlayTimeSessionHelper.GetTotalSeconds(game), Is.EqualTo(long.MaxValue));
+        });
+    }
+
+    [Test]
+    public void PreciseTotal_IncludesDailySecondRemaindersWithoutChangingCompatibilityMinutes()
+    {
+        Galgame game = new()
+        {
+            PlayedTimeSeconds = new Dictionary<string, long>
+            {
+                ["2026/8/23"] = 119,
+                ["2026/8/24"] = 122,
+            },
+        };
+
+        PlayTimeSessionHelper.RefreshDerivedState(game);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTime.Values.Sum(), Is.EqualTo(3));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(3));
+            Assert.That(PlayTimeSessionHelper.GetTotalSeconds(game), Is.EqualTo(241));
+        });
+    }
+
+    [Test]
+    public void MergeTime_PreservesLatestPreciseBoundaryAndClampsTotalMinutes()
+    {
+        DateTime latestBoundary = new(2026, 8, 24, 23, 59, 58);
+        Galgame game = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/23"] = int.MaxValue },
+        };
+        Galgame other = new()
+        {
+            PlayedTime = new Dictionary<string, int> { ["2026/8/24"] = int.MaxValue },
+            LastPlayTime = latestBoundary.AddSeconds(-1),
+            PlayTimeSessions =
+            [
+                new PlayTimeSession
+                {
+                    StartedAt = latestBoundary.AddMinutes(-1),
+                    EndedAt = latestBoundary,
+                },
+            ],
+        };
+
+        Assert.DoesNotThrow(() => game.MergeTime(other));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.TotalPlayTime, Is.EqualTo(int.MaxValue));
+            Assert.That(game.LastPlayTime, Is.EqualTo(latestBoundary));
+            Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void GalgameSerialization_PreservesPreciseSessions()
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = new DateTime(2026, 8, 19, 20, 0, 0),
+            EndedAt = new DateTime(2026, 8, 19, 20, 1, 2),
+            Kind = PlayTimeSessionKind.Imported,
+            CountsTowardPlayTime = false,
+            ActivityIntervals =
+            [
+                new PlayTimeActivityInterval
+                {
+                    StartedAt = new DateTime(2026, 8, 19, 20, 0, 5),
+                    EndedAt = new DateTime(2026, 8, 19, 20, 0, 55),
+                },
+            ],
+        };
+        Galgame game = new()
+        {
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/19"] = 62 },
+            PlayTimeSessions = [session],
+        };
+
+        Galgame restored = JsonConvert.DeserializeObject<Galgame>(JsonConvert.SerializeObject(game))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.PlayedTimeSeconds["2026/8/19"], Is.EqualTo(62));
+            Assert.That(restored.PlayTimeSessions, Has.Count.EqualTo(1));
+            Assert.That(restored.PlayTimeSessions[0].Id, Is.EqualTo(session.Id));
+            Assert.That(restored.PlayTimeSessions[0].Kind, Is.EqualTo(PlayTimeSessionKind.Imported));
+            Assert.That(restored.PlayTimeSessions[0].CountsTowardPlayTime, Is.False);
+            Assert.That(restored.PlayTimeSessions[0].ActivityIntervals, Has.Count.EqualTo(1));
+            Assert.That(restored.PlayTimeSessions[0].ActivityIntervals![0].StartedAt,
+                Is.EqualTo(session.ActivityIntervals![0].StartedAt));
+        });
+    }
+
+    [Test]
+    public void GalgameSerialization_PreservesMinuteSampleSegments()
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = new DateTime(2026, 8, 23, 20, 0, 0),
+            EndedAt = new DateTime(2026, 8, 23, 20, 5, 30),
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = new Dictionary<string, int> { ["2026/8/23"] = 5 },
+            ActivityIntervals = [],
+        };
+        Galgame game = new() { PlayTimeSessions = [session] };
+
+        Galgame restored = JsonConvert.DeserializeObject<Galgame>(JsonConvert.SerializeObject(game))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restored.PlayTimeSessions, Has.Count.EqualTo(1));
+            Assert.That(restored.PlayTimeSessions[0].Kind, Is.EqualTo(PlayTimeSessionKind.MinuteSampled));
+            Assert.That(restored.PlayTimeSessions[0].SampledMinutesByDay["2026/8/23"], Is.EqualTo(5));
+        });
+    }
+}

--- a/GalgameManager.Test/Helpers/PlayTimeSessionHelperTest.cs
+++ b/GalgameManager.Test/Helpers/PlayTimeSessionHelperTest.cs
@@ -792,6 +792,46 @@ public class PlayTimeSessionHelperTest
     }
 
     [Test]
+    public void MergeTime_ReconcilesDistinctCountedSessionsOnTheSameDay()
+    {
+        DateTime date = new(2026, 8, 24, 10, 0, 0);
+        Galgame game = new()
+        {
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/24"] = 40 },
+            PlayTimeSessions =
+            [
+                new PlayTimeSession
+                {
+                    StartedAt = date,
+                    EndedAt = date.AddSeconds(40),
+                },
+            ],
+        };
+        Galgame other = new()
+        {
+            PlayedTimeSeconds = new Dictionary<string, long> { ["2026/8/24"] = 40 },
+            PlayTimeSessions =
+            [
+                new PlayTimeSession
+                {
+                    StartedAt = date.AddMinutes(1),
+                    EndedAt = date.AddMinutes(1).AddSeconds(40),
+                },
+            ],
+        };
+
+        game.MergeTime(other);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(game.PlayedTimeSeconds["2026/8/24"], Is.EqualTo(80));
+            Assert.That(game.PlayedTime["2026/8/24"], Is.EqualTo(1));
+            Assert.That(game.TotalPlayTime, Is.EqualTo(1));
+            Assert.That(game.PlayTimeSessions, Has.Count.EqualTo(2));
+        });
+    }
+
+    [Test]
     public void GalgameSerialization_PreservesPreciseSessions()
     {
         PlayTimeSession session = new()

--- a/GalgameManager.Test/Helpers/PlayedTimeViewModelItemTest.cs
+++ b/GalgameManager.Test/Helpers/PlayedTimeViewModelItemTest.cs
@@ -1,0 +1,105 @@
+using GalgameManager.Helpers;
+using GalgameManager.Models;
+using GalgameManager.ViewModels;
+
+namespace GalgameManager.Test.Helpers;
+
+[TestFixture]
+public class PlayedTimeViewModelItemTest
+{
+    [Test]
+    public void MinuteModeSubMinuteTotal_RemainsVisibleWithoutRoundingUp()
+    {
+        PlayTimeDayViewModelItem item = new(
+            new DateTime(2026, 8, 26),
+            31,
+            0,
+            [],
+            [],
+            false,
+            false,
+            true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(item.TotalSeconds, Is.EqualTo(31));
+            Assert.That(item.TotalText, Is.EqualTo("<1m"));
+        });
+    }
+
+    [Test]
+    public void ApplySnapshot_PreservesExpandedObjectsAndUpdatesDisplayedValues()
+    {
+        DateTime date = new(2026, 8, 26);
+        PlayTimeSession session = new()
+        {
+            StartedAt = date.AddHours(1),
+            EndedAt = date.AddHours(1).AddMinutes(1),
+            ActivityIntervals =
+            [
+                new PlayTimeActivityInterval
+                {
+                    StartedAt = date.AddHours(1),
+                    EndedAt = date.AddHours(1).AddMinutes(1),
+                },
+            ],
+        };
+        PlayTimeSessionViewModelItem existingSession = CreateSessionItem(session, date, 60, true);
+        PlayTimeDayViewModelItem existingDay = CreateDayItem(date, 60, existingSession, true);
+
+        session.EndedAt = date.AddHours(1).AddMinutes(2);
+        session.ActivityIntervals![0].EndedAt = session.EndedAt;
+        PlayTimeSessionViewModelItem updatedSession = CreateSessionItem(session, date, 120, false);
+        PlayTimeDayViewModelItem updatedDay = CreateDayItem(date, 120, updatedSession, false);
+
+        existingDay.ApplySnapshot(updatedDay);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(existingDay.IsExpanded, Is.True);
+            Assert.That(existingDay.TotalSeconds, Is.EqualTo(120));
+            Assert.That(existingDay.TotalText, Is.EqualTo(updatedDay.TotalText));
+            Assert.That(existingDay.Sessions, Has.Count.EqualTo(1));
+            Assert.That(existingDay.Sessions[0], Is.SameAs(existingSession));
+            Assert.That(existingSession.IsExpanded, Is.True);
+            Assert.That(existingSession.Duration, Is.EqualTo(updatedSession.Duration));
+            Assert.That(existingSession.ActivityIntervals, Has.Count.EqualTo(1));
+        });
+    }
+
+    private static PlayTimeDayViewModelItem CreateDayItem(
+        DateTime date,
+        long seconds,
+        PlayTimeSessionViewModelItem session,
+        bool isExpanded) => new(
+        date,
+        seconds,
+        0,
+        [],
+        [session],
+        true,
+        true,
+        false,
+        isExpanded);
+
+    private static PlayTimeSessionViewModelItem CreateSessionItem(
+        PlayTimeSession session,
+        DateTime date,
+        long seconds,
+        bool isExpanded) => new(
+        session,
+        new PlayTimeDaySegment(
+            session.Id,
+            date,
+            session.StartedAt,
+            session.EndedAt,
+            seconds,
+            session.IsOpen,
+            session.Kind,
+            session.CountsTowardPlayTime),
+        _ => Task.CompletedTask,
+        _ => Task.CompletedTask,
+        _ => Task.CompletedTask,
+        false,
+        isExpanded);
+}

--- a/GalgameManager.Test/Helpers/PlayedTimeViewModelItemTest.cs
+++ b/GalgameManager.Test/Helpers/PlayedTimeViewModelItemTest.cs
@@ -28,6 +28,26 @@ public class PlayedTimeViewModelItemTest
     }
 
     [Test]
+    public void PreciseModeSubMinuteAggregateWithoutCountedSession_RemainsVisibleWithoutRoundingUp()
+    {
+        PlayTimeDayViewModelItem item = new(
+            new DateTime(2026, 8, 26),
+            31,
+            31,
+            [],
+            [],
+            true,
+            false,
+            true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(item.TotalSeconds, Is.EqualTo(31));
+            Assert.That(item.TotalText, Is.EqualTo("LessThanOneMinute"));
+        });
+    }
+
+    [Test]
     public void ApplySnapshot_PreservesExpandedObjectsAndUpdatesDisplayedValues()
     {
         DateTime date = new(2026, 8, 26);

--- a/GalgameManager.Test/Models/GalgameInstallationTest.cs
+++ b/GalgameManager.Test/Models/GalgameInstallationTest.cs
@@ -174,6 +174,25 @@ public class GalgameInstallationTest
     }
 
     [Test]
+    public void LocalInstallationConfig_ClonePreservesLaunchDialogSetting()
+    {
+        LocalInstallationConfig config = new()
+        {
+            ExePath = @"D:\Library\Example\game.exe",
+            DelayPlayTimeUntilMainWindow = true,
+        };
+
+        LocalInstallationConfig clone = config.Clone();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clone, Is.Not.SameAs(config));
+            Assert.That(clone.ExePath, Is.EqualTo(config.ExePath));
+            Assert.That(clone.DelayPlayTimeUntilMainWindow, Is.True);
+        });
+    }
+
+    [Test]
     public void VersionTwoMeta_PreservesOnlyItsInstallationConfiguration()
     {
         GameMetaBackup backup = new()

--- a/GalgameManager.Test/Services/BgTaskServiceTest.cs
+++ b/GalgameManager.Test/Services/BgTaskServiceTest.cs
@@ -84,6 +84,66 @@ public class BgTaskServiceTest : ServiceTestBase
         await addTask;
     }
 
+    [Test]
+    public async Task AddBgTask_ConcurrentDuplicates_OnlyOneRuns()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask[] tasks = Enumerable.Range(0, 32)
+            .Select(_ => new DeduplicatedTestBgTask("same", gate))
+            .ToArray();
+        var addedCount = 0;
+        service.BgTaskAdded += _ => Interlocked.Increment(ref addedCount);
+
+        Task[] additions = tasks.Select(service.AddBgTask).ToArray();
+        await Task.Delay(100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.GetBgTasks().Count(), Is.EqualTo(1));
+            Assert.That(tasks.Count(task => task.Ran), Is.EqualTo(1));
+            Assert.That(addedCount, Is.EqualTo(1));
+        });
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
+    [Test]
+    public async Task AddBgTask_DuplicateAfterCompletion_RunsAgain()
+    {
+        BgTaskService service = CreateService();
+        DeduplicatedTestBgTask first = new("same");
+        DeduplicatedTestBgTask second = new("same");
+
+        await service.AddBgTask(first);
+        await service.AddBgTask(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Ran, Is.True);
+            Assert.That(second.Ran, Is.True);
+            Assert.That(service.GetBgTasks(), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task AddBgTask_DifferentDeduplicationKeys_RunTogether()
+    {
+        BgTaskService service = CreateService();
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeduplicatedTestBgTask first = new("first", gate);
+        DeduplicatedTestBgTask second = new("second", gate);
+
+        Task[] additions = [service.AddBgTask(first), service.AddBgTask(second)];
+        await Task.Delay(100);
+
+        Assert.That(service.GetBgTasks().Count(), Is.EqualTo(2));
+
+        gate.SetResult();
+        await Task.WhenAll(additions);
+    }
+
     // 验证后台任务的持久化与恢复闭环：SaveBgTasksString把运行中的任务写入文件，
     // 新实例ResolvedBgTasksAsync读回、反序列化、RecoverFromJson并重新运行，最后删除文件
     [Test]
@@ -118,6 +178,34 @@ public class BgTaskServiceTest : ServiceTestBase
         // 等恢复的任务跑完并从列表移除，避免残留状态影响后续用例
         await Task.Delay(800);
         Assert.That(service2.GetBgTasks(), Is.Empty);
+    }
+
+    [Test]
+    public async Task Resolve_DuplicatePersistedTasks_OnlyOneIsRestored()
+    {
+        RecoverableDeduplicatedTestBgTask.Reset();
+        BgTaskService service = CreateService();
+        service.RegisterBgTaskType(typeof(RecoverableDeduplicatedTestBgTask), "-dedupe");
+        string json = JsonConvert.SerializeObject(new RecoverableDeduplicatedTestBgTask
+        {
+            Key = "same",
+        });
+        string persisted = $"-dedupe {json.ToBase64()} -dedupe {json.ToBase64()} ";
+        _fileService.Save(AppStoragePaths.LocalDataPath, BgTaskFileName, persisted);
+        string file = Path.Combine(AppStoragePaths.LocalDataPath, BgTaskFileName);
+        for (var i = 0; i < 50 && !File.Exists(file); i++) await Task.Delay(100);
+
+        await service.ResolvedBgTasksAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RecoverableDeduplicatedTestBgTask.RunCount, Is.EqualTo(1));
+            Assert.That(service.GetBgTasks().OfType<RecoverableDeduplicatedTestBgTask>().Count(), Is.EqualTo(1));
+        });
+
+        RecoverableDeduplicatedTestBgTask.Gate.SetResult();
+        await Task.Delay(800);
+        Assert.That(service.GetBgTasks(), Is.Empty);
     }
 
     public class TestBgTask : BgTaskBase
@@ -160,5 +248,55 @@ public class BgTaskServiceTest : ServiceTestBase
         protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
 
         protected override Task RunInternal() => Task.CompletedTask;
+    }
+
+    public class DeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        private readonly TaskCompletionSource? _gate;
+
+        public DeduplicatedTestBgTask(string key, TaskCompletionSource? gate = null)
+        {
+            DeduplicationKey = key;
+            _gate = gate;
+        }
+
+        public string? DeduplicationKey { get; }
+        public bool Ran { get; private set; }
+        public override string Title => "DeduplicatedTestBgTask";
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Ran = true;
+            if (_gate is not null) await _gate.Task;
+        }
+    }
+
+    public class RecoverableDeduplicatedTestBgTask : BgTaskBase, IDeduplicatedBgTask
+    {
+        public static TaskCompletionSource Gate { get; private set; } = NewGate();
+        public static int RunCount;
+
+        public string? Key { get; set; }
+        public string? DeduplicationKey => Key;
+        public override string Title => "RecoverableDeduplicatedTestBgTask";
+
+        public static void Reset()
+        {
+            Gate = NewGate();
+            RunCount = 0;
+        }
+
+        protected override Task RecoverFromJsonInternal() => Task.CompletedTask;
+
+        protected override async Task RunInternal()
+        {
+            Interlocked.Increment(ref RunCount);
+            await Gate.Task;
+        }
+
+        private static TaskCompletionSource NewGate() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/GalgameManager.WinApp.Base/Models/Galgame.cs
+++ b/GalgameManager.WinApp.Base/Models/Galgame.cs
@@ -57,6 +57,16 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
     public string? HeaderImageUrl { get; set; }
     // ReSharper disable once FieldCanBeMadeReadOnly.Global
     public Dictionary<string, int> PlayedTime { get; set; }= new(); //ShortDateString() -> PlayedTime, 分钟
+    /// <summary>
+    /// 精确到秒的逐日游玩汇总。首次写入某日时会从 <see cref="PlayedTime"/> 的旧分钟数初始化，
+    /// 因此旧数据与新数据可以无损叠加；旧版客户端会安全忽略此字段。
+    /// </summary>
+    public Dictionary<string, long> PlayedTimeSeconds { get; set; } = new();
+    /// <summary>
+    /// 原生逐段游玩记录。精确模式保存实际计时区间，分钟模式只保存每次启动贡献的整分钟采样数；
+    /// 启动弹窗等待阶段不会创建有效计时分段。
+    /// </summary>
+    public List<PlayTimeSession> PlayTimeSessions { get; set; } = new();
     [ObservableProperty] private LockableProperty<string> _name = "";
     [ObservableProperty] private string _cnName = "";
     [ObservableProperty] private LockableProperty<string> _originalName = "";
@@ -628,13 +638,41 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
             if (!PlayedTime.TryAdd(key, value))
                 PlayedTime[key] = int.Max(value, PlayedTime[key]);
         }
+        // 秒级数据只在本地原生保存，服务端仍同步分钟。若云端分钟数更大，向上补齐本地秒数，
+        // 避免旧客户端或另一台设备的记录在合并后又被精确计时兼容层降回去。
+        foreach ((string key, int minutes) in PlayedTime.ToArray())
+        {
+            long compatibleSeconds = Math.Max(0, minutes) * 60L;
+            if (!PlayedTimeSeconds.TryAdd(key, compatibleSeconds))
+                PlayedTimeSeconds[key] = Math.Max(PlayedTimeSeconds[key], compatibleSeconds);
+        }
+        foreach ((string key, long seconds) in other.PlayedTimeSeconds)
+        {
+            if (!PlayedTimeSeconds.TryAdd(key, Math.Max(0, seconds)))
+                PlayedTimeSeconds[key] = Math.Max(PlayedTimeSeconds[key], Math.Max(0, seconds));
+        }
+        foreach (PlayTimeSession session in other.PlayTimeSessions)
+        {
+            if (PlayTimeSessions.All(existing => existing.Id != session.Id))
+                PlayTimeSessions.Add(session.Clone());
+        }
         // 排序PlayedTime
         PlayedTime = PlayedTime.OrderBy(pair => Utils.TryParseDateGuessCulture(pair.Key))
             .ToDictionary(pair => pair.Key, pair => pair.Value);
-        TotalPlayTime = PlayedTime.Values.Sum();
-        LastPlayTime = PlayedTime.Count > 0
+        long totalMinutes = PlayedTime.Values.Aggregate(0L, (total, minutes) =>
+            total > long.MaxValue - Math.Max(0, minutes)
+                ? long.MaxValue
+                : total + Math.Max(0, minutes));
+        TotalPlayTime = checked((int)Math.Min(int.MaxValue, totalMinutes));
+        DateTime latestLegacy = PlayedTime.Count > 0
             ? PlayedTime.Keys.Select(Utils.TryParseDateGuessCulture).Max()
             : DateTime.MinValue;
+        DateTime latestSession = PlayTimeSessions
+            .Where(session => session.EndedAt >= session.StartedAt)
+            .Select(session => session.EndedAt)
+            .DefaultIfEmpty(DateTime.MinValue)
+            .Max();
+        LastPlayTime = new[] { LastPlayTime, other.LastPlayTime, latestLegacy, latestSession }.Max();
         ReleaseDate.Value = other.ReleaseDate.Value > ReleaseDate.Value ? other.ReleaseDate.Value : ReleaseDate.Value;
     }
 

--- a/GalgameManager.WinApp.Base/Models/Galgame.cs
+++ b/GalgameManager.WinApp.Base/Models/Galgame.cs
@@ -656,6 +656,7 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
             if (PlayTimeSessions.All(existing => existing.Id != session.Id))
                 PlayTimeSessions.Add(session.Clone());
         }
+        EnsurePlayTimeSessionMinimums();
         // 排序PlayedTime
         PlayedTime = PlayedTime.OrderBy(pair => Utils.TryParseDateGuessCulture(pair.Key))
             .ToDictionary(pair => pair.Key, pair => pair.Value);
@@ -674,6 +675,76 @@ public partial class Galgame : ObservableObject, IDisplayableGameObject
             .Max();
         LastPlayTime = new[] { LastPlayTime, other.LastPlayTime, latestLegacy, latestSession }.Max();
         ReleaseDate.Value = other.ReleaseDate.Value > ReleaseDate.Value ? other.ReleaseDate.Value : ReleaseDate.Value;
+    }
+
+    private void EnsurePlayTimeSessionMinimums()
+    {
+        Dictionary<DateTime, long> minimums = [];
+        foreach (PlayTimeSession session in PlayTimeSessions)
+        {
+            if (session.Kind == PlayTimeSessionKind.MinuteSampled)
+            {
+                foreach ((string key, int minutes) in session.SampledMinutesByDay ?? [])
+                {
+                    DateTime date = Utils.TryParseDateGuessCulture(key);
+                    if (date.Year > 1900 && minutes > 0) AddMinimum(date.Date, minutes * 60L);
+                }
+                continue;
+            }
+
+            if (!session.CountsTowardPlayTime) continue;
+            IEnumerable<PlayTimeActivityInterval> intervals = session.ActivityIntervals is null
+                ? session.EndedAt > session.StartedAt
+                    ? [new PlayTimeActivityInterval { StartedAt = session.StartedAt, EndedAt = session.EndedAt }]
+                    : []
+                : session.ActivityIntervals.Where(interval => interval.EndedAt > interval.StartedAt);
+            foreach (PlayTimeActivityInterval interval in intervals)
+            {
+                DateTime cursor = interval.StartedAt;
+                while (cursor < interval.EndedAt)
+                {
+                    DateTime dayEnd = cursor.Date == DateTime.MaxValue.Date
+                        ? DateTime.MaxValue
+                        : cursor.Date.AddDays(1);
+                    DateTime segmentEnd = interval.EndedAt < dayEnd ? interval.EndedAt : dayEnd;
+                    long seconds = Math.Max(0, (long)Math.Round(
+                        (segmentEnd - cursor).TotalSeconds,
+                        MidpointRounding.AwayFromZero));
+                    AddMinimum(cursor.Date, seconds);
+                    if (segmentEnd <= cursor) break;
+                    cursor = segmentEnd;
+                }
+            }
+        }
+
+        foreach ((DateTime date, long minimumSeconds) in minimums)
+        {
+            string normalizedKey = date.ToString("yyyy/M/d", System.Globalization.CultureInfo.InvariantCulture);
+            string key = PlayedTimeSeconds.Keys.FirstOrDefault(existingKey =>
+                             string.Equals(existingKey, normalizedKey, StringComparison.Ordinal))
+                         ?? PlayedTimeSeconds.Keys.FirstOrDefault(existingKey =>
+                             Utils.TryParseDateGuessCulture(existingKey).Date == date)
+                         ?? PlayedTime.Keys.FirstOrDefault(existingKey =>
+                             Utils.TryParseDateGuessCulture(existingKey).Date == date)
+                         ?? normalizedKey;
+            long currentSeconds = PlayedTimeSeconds.TryGetValue(key, out long value) ? Math.Max(0, value) : 0;
+            long mergedSeconds = Math.Max(currentSeconds, minimumSeconds);
+            if (currentSeconds != mergedSeconds || !PlayedTimeSeconds.ContainsKey(key))
+                PlayedTimeSeconds[key] = mergedSeconds;
+
+            int compatibleMinutes = checked((int)Math.Min(int.MaxValue, mergedSeconds / 60));
+            if (compatibleMinutes > 0 &&
+                (!PlayedTime.TryGetValue(key, out int currentMinutes) || currentMinutes < compatibleMinutes))
+                PlayedTime[key] = compatibleMinutes;
+        }
+        return;
+
+        void AddMinimum(DateTime date, long seconds)
+        {
+            if (seconds <= 0) return;
+            minimums.TryGetValue(date, out long current);
+            minimums[date] = current > long.MaxValue - seconds ? long.MaxValue : current + seconds;
+        }
     }
 
     public string GetLogName() => $"Galgame_{(Name.Value ?? string.Empty).RemoveInvalidChars()}.txt";

--- a/GalgameManager.WinApp.Base/Models/Msgs/GalgameEvents.cs
+++ b/GalgameManager.WinApp.Base/Models/Msgs/GalgameEvents.cs
@@ -9,6 +9,12 @@ namespace GalgameManager.WinApp.Base.Models.Msgs;
 public class GalgamePlayedMessage(Galgame galgame) : ValueChangedMessage<Galgame>(galgame);
 
 /// <summary>
+/// 仅在启动弹窗判断完成、原生计时可以创建游玩时段后发送。
+/// 需要正式游玩生命周期的插件应优先监听此消息，而不是 <see cref="GalgamePlayedMessage"/>。
+/// </summary>
+public class GalgamePlayTimeRecordingStartedMessage(Galgame galgame) : ValueChangedMessage<Galgame>(galgame);
+
+/// <summary>
 /// 将游戏已保存映射状态的不可变副本传递给正在运行的按键映射任务。
 /// </summary>
 public class KeyMappingsChangedMessage : AsyncRequestMessage<bool>

--- a/GalgameManager.WinApp.Base/Models/PlayTimeSession.cs
+++ b/GalgameManager.WinApp.Base/Models/PlayTimeSession.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GalgameManager.Models;
+
+/// <summary>
+/// 说明原生游玩时段的创建来源。
+/// </summary>
+public enum PlayTimeSessionKind
+{
+    Native = 0,
+    Imported = 1,
+    Manual = 2,
+    MinuteSampled = 3,
+}
+
+/// <summary>
+/// PotatoVN 的单次游戏启动记录。外层起止时间描述本次启动的生命周期。
+/// 精确模式实际计入的时间由 <see cref="ActivityIntervals"/> 保存，分钟模式的柱状图分段
+/// 则由 <see cref="SampledMinutesByDay"/> 保存。
+/// 时段保存在 <see cref="Galgame"/> 中，旧版逐日分钟汇总仍用于兼容旧客户端和服务端同步。
+/// </summary>
+public sealed class PlayTimeSession
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public DateTime StartedAt { get; set; }
+    public DateTime EndedAt { get; set; }
+    public bool IsOpen { get; set; }
+    public Guid? InstallationId { get; set; }
+    public PlayTimeSessionKind Kind { get; set; } = PlayTimeSessionKind.Native;
+    public bool CountsTowardPlayTime { get; set; } = true;
+
+    /// <summary>
+    /// 分钟级计时模式下，本次启动在各日期实际贡献的整分钟采样数。
+    /// 该字段只用于还原柱状图分段，逐日总时长仍以游戏的分钟汇总为准。
+    /// </summary>
+    public Dictionary<string, int> SampledMinutesByDay { get; set; } = new();
+
+    /// <summary>
+    /// 本次启动中实际计入游玩时间的片段。值为 <see langword="null"/> 表示旧数据，
+    /// 此时继续使用 <see cref="StartedAt"/> 到 <see cref="EndedAt"/> 作为单一计时片段；
+    /// 空列表则表示已经使用新格式，但本次启动尚未累计有效时间。
+    /// </summary>
+    public List<PlayTimeActivityInterval>? ActivityIntervals { get; set; }
+
+    public PlayTimeSession Clone() => new()
+    {
+        Id = Id,
+        StartedAt = StartedAt,
+        EndedAt = EndedAt,
+        IsOpen = IsOpen,
+        InstallationId = InstallationId,
+        Kind = Kind,
+        CountsTowardPlayTime = CountsTowardPlayTime,
+        SampledMinutesByDay = SampledMinutesByDay is null
+            ? new Dictionary<string, int>()
+            : new Dictionary<string, int>(SampledMinutesByDay),
+        ActivityIntervals = ActivityIntervals?.Select(interval => interval.Clone()).ToList(),
+    };
+}
+
+/// <summary>
+/// 单次游戏启动中连续计入游玩时间的区间；仅前台计时时，每次暂停与恢复会产生新的内部区间，
+/// 但不会拆成新的外层游玩时段。
+/// </summary>
+public sealed class PlayTimeActivityInterval
+{
+    public DateTime StartedAt { get; set; }
+    public DateTime EndedAt { get; set; }
+
+    public PlayTimeActivityInterval Clone() => new()
+    {
+        StartedAt = StartedAt,
+        EndedAt = EndedAt,
+    };
+}

--- a/GalgameManager.WinApp.Base/Models/Sources/GalgameAndPath.cs
+++ b/GalgameManager.WinApp.Base/Models/Sources/GalgameAndPath.cs
@@ -136,6 +136,7 @@ public partial class LocalInstallationConfig : ObservableObject
     [ObservableProperty] private bool _highDpi; // 是否启用高DPI替代缩放
     [ObservableProperty] private GamePortablePath? _detectedSavePath; // 当前实例的探测存档路径
     [ObservableProperty] private string? _savePath; // 当前实例的云存档本地路径
+    [ObservableProperty] private bool _delayPlayTimeUntilMainWindow; // 声明/启动器窗口切换后再开始计时
     [ObservableProperty] private DateTime _lastSuccessfulLaunchTime = DateTime.MinValue; // 上次成功启动时间
 
     /// <summary>
@@ -153,6 +154,7 @@ public partial class LocalInstallationConfig : ObservableObject
         HighDpi = HighDpi,
         DetectedSavePath = DetectedSavePath,
         SavePath = SavePath,
+        DelayPlayTimeUntilMainWindow = DelayPlayTimeUntilMainWindow,
         LastSuccessfulLaunchTime = LastSuccessfulLaunchTime,
     };
 

--- a/GalgameManager/Enums/KeyValues.cs
+++ b/GalgameManager/Enums/KeyValues.cs
@@ -44,6 +44,8 @@ public static class KeyValues
 
     //游玩相关
     public const string RecordOnlyWhenForeground = "recordOnlyWhenForeground"; //bool, 是否只在游戏窗口在前台时记录游玩时间
+    public const string PrecisePlayTime = "precisePlayTime"; //bool, 是否启用秒级采集、单次启动记录及精确显示编辑
+    public const string PlayedTimeDateDescending = "playedTimeDateDescending"; //bool, 游玩时间详情是否按日期倒序排列
     public const string PlayingWindowMode = "playingWindowMode"; // WindowMode,游玩时窗口模式
     public const string LocaleEmulatorPath = "localeEmulatorPath"; //string?, 本地模拟器路径
     public const string MagpieTotalSwitch = "magpieTotalSwitch"; //bool, 是否启用Magpie总开关

--- a/GalgameManager/Helpers/Converter/TimeToDisplayTimeConverter.cs
+++ b/GalgameManager/Helpers/Converter/TimeToDisplayTimeConverter.cs
@@ -15,7 +15,9 @@ public class TimeToDisplayTimeConverter : IValueConverter
             return string.Empty;
         }
         
-        var time = (int)value;
+        int time = value is long longValue
+            ? checked((int)Math.Min(int.MaxValue, longValue))
+            : (int)value;
         return Convert(time);
     }
 
@@ -24,8 +26,74 @@ public class TimeToDisplayTimeConverter : IValueConverter
     public static string Convert(int value)
     {
         var timeAsHour = App.GetService<ILocalSettingsService>().ReadSettingAsync<bool>(KeyValues.TimeAsHour).Result;
+        return ConvertMinutes(value, timeAsHour);
+    }
+
+    public static string ConvertSeconds(long value)
+    {
+        bool timeAsHour = App.GetService<ILocalSettingsService>()
+            .ReadSettingAsync<bool>(KeyValues.TimeAsHour).Result;
+        return ConvertSeconds(value, timeAsHour);
+    }
+
+    public static string ConvertMinutes(int value, bool timeAsHour)
+    {
+        int minutes = Math.Max(0, value);
         if (timeAsHour)
-            return value > 60 ? $"{value / 60}h{value % 60}m" : $"{value}m";
-        return $"{value} {"Minute".GetLocalized()}";
+            return minutes > 60 ? $"{minutes / 60}h{minutes % 60}m" : $"{minutes}m";
+        return $"{minutes} {"Minute".GetLocalized()}";
+    }
+
+    public static string ConvertWholeMinutesWithUnits(long value, bool timeAsHour)
+    {
+        long minutes = Math.Max(0, value);
+        long hours = minutes / 60;
+        if (timeAsHour && hours > 0)
+            return $"{hours} {"Hour".GetLocalized()} {minutes % 60} {"Minute".GetLocalized()}";
+        return $"{minutes} {"Minute".GetLocalized()}";
+    }
+
+    /// <summary>
+    /// 将秒数按分钟模式的原版格式显示。正数不足一分钟时保留其存在性，但不会虚增为一分钟。
+    /// </summary>
+    public static string ConvertMinuteModeSeconds(long value, bool timeAsHour)
+    {
+        long seconds = Math.Max(0, value);
+        if (seconds is > 0 and < 60)
+            return timeAsHour ? "<1m" : "LessThanOneMinute".GetLocalized();
+        return ConvertMinutes(
+            checked((int)Math.Min(int.MaxValue, seconds / 60)),
+            timeAsHour);
+    }
+
+    /// <summary>
+    /// 将秒数按本地化的小时／分钟单位显示，不展示秒级余数。
+    /// </summary>
+    public static string ConvertWholeMinuteSecondsWithUnits(long value, bool timeAsHour)
+    {
+        long seconds = Math.Max(0, value);
+        return seconds is > 0 and < 60
+            ? "LessThanOneMinute".GetLocalized()
+            : ConvertWholeMinutesWithUnits(seconds / 60, timeAsHour);
+    }
+
+    public static string ConvertSeconds(long value, bool timeAsHour)
+    {
+        long seconds = Math.Max(0, value);
+        long hours = seconds / 3600;
+        long minutes = seconds % 3600 / 60;
+        long remainder = seconds % 60;
+        if (timeAsHour && hours > 0)
+            return $"{hours} {"Hour".GetLocalized()} {minutes} {"Minute".GetLocalized()} {remainder} {"Second".GetLocalized()}";
+        if (!timeAsHour)
+        {
+            long totalMinutes = seconds / 60;
+            return totalMinutes > 0
+                ? $"{totalMinutes} {"Minute".GetLocalized()} {remainder} {"Second".GetLocalized()}"
+                : $"{remainder} {"Second".GetLocalized()}";
+        }
+        if (minutes > 0)
+            return $"{minutes} {"Minute".GetLocalized()} {remainder} {"Second".GetLocalized()}";
+        return $"{remainder} {"Second".GetLocalized()}";
     }
 }

--- a/GalgameManager/Helpers/GameLaunchWindowTracker.cs
+++ b/GalgameManager/Helpers/GameLaunchWindowTracker.cs
@@ -1,0 +1,101 @@
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 从游戏启动前开始保存安装目录中新进程的窗口变化，避免后台任务附着较晚时漏掉启动弹窗。
+/// </summary>
+public sealed class GameLaunchWindowTracker
+{
+    private static readonly TimeSpan InitialObservationInterval = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan StableObservationInterval = TimeSpan.FromMilliseconds(100);
+    private readonly object _syncRoot = new();
+    private readonly GameWindowTransitionGate _gate = new();
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly Queue<GameWindowSnapshot> _pendingLogSnapshots = new();
+    private GameWindowSnapshot? _lastLoggedSnapshot;
+    private GameWindowSnapshot? _confirmedSnapshot;
+    private Task? _observationTask;
+
+    public GameWindowTransitionStage Stage
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _gate.Stage;
+        }
+    }
+
+    public GameWindowSnapshot? ConfirmedSnapshot
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _confirmedSnapshot;
+        }
+    }
+
+    /// <summary>
+    /// 在启动操作执行前开始观察，确保短命启动进程退出前后的窗口都能进入同一段历史。
+    /// </summary>
+    public void Start(string directoryPrefix, IReadOnlyCollection<int> preExistingProcessIds)
+    {
+        lock (_syncRoot)
+        {
+            if (_observationTask is not null) return;
+            HashSet<int> excluded = new(preExistingProcessIds);
+            _observationTask = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!_cancellation.IsCancellationRequested && ConfirmedSnapshot is null)
+                    {
+                        GameWindowSnapshot? snapshot =
+                            GameProcessDetector.TryGetPrimaryWindowSnapshotInDirectory(directoryPrefix, excluded);
+                        _ = Observe(snapshot);
+                        TimeSpan interval = Stage == GameWindowTransitionStage.WaitingForBaseline
+                            ? InitialObservationInterval
+                            : StableObservationInterval;
+                        await Task.Delay(interval, _cancellation.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // 启动失败、任务结束或正式窗口已经确认时正常停止观察。
+                }
+            });
+        }
+    }
+
+    /// <summary>
+    /// 将已经附着进程的窗口也并入同一状态机，补足目录路径不可读取的受保护进程场景。
+    /// </summary>
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        lock (_syncRoot)
+        {
+            if (snapshot is { IsUsable: true } current &&
+                (!_lastLoggedSnapshot.HasValue ||
+                 GameWindowTransitionGate.HasMeaningfulTransition(_lastLoggedSnapshot.Value, current)))
+            {
+                _pendingLogSnapshots.Enqueue(current);
+                _lastLoggedSnapshot = current;
+            }
+
+            if (!_gate.Observe(snapshot) || !snapshot.HasValue) return false;
+            _confirmedSnapshot ??= snapshot.Value;
+            _cancellation.Cancel();
+            return true;
+        }
+    }
+
+    public IReadOnlyList<GameWindowSnapshot> DrainLogSnapshots()
+    {
+        lock (_syncRoot)
+        {
+            List<GameWindowSnapshot> result = [];
+            while (_pendingLogSnapshots.TryDequeue(out GameWindowSnapshot snapshot)) result.Add(snapshot);
+            return result;
+        }
+    }
+
+    public void Stop() => _cancellation.Cancel();
+}

--- a/GalgameManager/Helpers/GameProcessDetector.cs
+++ b/GalgameManager/Helpers/GameProcessDetector.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace GalgameManager.Helpers;
 
@@ -8,6 +10,41 @@ namespace GalgameManager.Helpers;
 /// </summary>
 public static class GameProcessDetector
 {
+    private delegate bool EnumWindowsProc(nint windowHandle, nint parameter);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(EnumWindowsProc callback, nint parameter);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(nint windowHandle);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(nint windowHandle, out uint processId);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(nint windowHandle, out NativeRect rect);
+
+    [DllImport("user32.dll")]
+    private static extern nint GetForegroundWindow();
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(nint windowHandle, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(nint windowHandle, StringBuilder className, int maxCount);
+
     /// <summary>
     /// 在指定时间窗口内轮询，等待可执行文件路径位于游戏目录下的进程出现，返回最佳候选。
     /// </summary>
@@ -42,7 +79,7 @@ public static class GameProcessDetector
             }
             catch
             {
-                // ignored
+                // 单个进程拒绝访问时跳过，继续采集其余进程。
             }
             finally
             {
@@ -56,7 +93,8 @@ public static class GameProcessDetector
     /// 枚举可执行文件路径位于目录前缀下的进程，返回最佳候选（优先有主窗口的，其次启动时间最晚的）。
     /// </summary>
     public static Process? FindBestProcessInDirectory(string directoryPrefix,
-        IReadOnlyCollection<int>? excludeProcessIds = null)
+        IReadOnlyCollection<int>? excludeProcessIds = null,
+        string? requiredProcessName = null)
     {
         Process? best = null;
         foreach (Process process in Process.GetProcesses())
@@ -64,6 +102,9 @@ public static class GameProcessDetector
             try
             {
                 if (excludeProcessIds?.Contains(process.Id) == true ||
+                    (!string.IsNullOrWhiteSpace(requiredProcessName) &&
+                     !string.Equals(process.ProcessName, requiredProcessName,
+                         StringComparison.OrdinalIgnoreCase)) ||
                     !IsInDirectory(process, directoryPrefix))
                 {
                     process.Dispose();
@@ -101,6 +142,77 @@ public static class GameProcessDetector
     }
 
     /// <summary>
+    /// 获取安装目录内本次启动新出现进程的主要可见窗口。优先返回前台窗口，
+    /// 没有前台窗口时返回面积最大的窗口，用于在正式进程附着前保存启动窗口历史。
+    /// </summary>
+    public static GameWindowSnapshot? TryGetPrimaryWindowSnapshotInDirectory(string directoryPrefix,
+        IReadOnlyCollection<int>? excludeProcessIds = null)
+    {
+        nint foregroundWindow = GetForegroundWindow();
+        GameWindowSnapshot? foreground = null;
+        GameWindowSnapshot? largest = null;
+        long largestArea = -1;
+        HashSet<int> acceptedProcessIds = [];
+        HashSet<int> rejectedProcessIds = excludeProcessIds is null ? [] : new HashSet<int>(excludeProcessIds);
+        EnumWindowsProc callback = (windowHandle, _) =>
+        {
+            if (!IsWindowVisible(windowHandle) ||
+                GetWindowThreadProcessId(windowHandle, out uint rawProcessId) == 0 || rawProcessId == 0 ||
+                !GetWindowRect(windowHandle, out NativeRect rect)) return true;
+
+            int processId = unchecked((int)rawProcessId);
+            if (rejectedProcessIds.Contains(processId)) return true;
+            if (!acceptedProcessIds.Contains(processId))
+            {
+                try
+                {
+                    using Process process = Process.GetProcessById(processId);
+                    if (!IsInDirectory(process, directoryPrefix))
+                    {
+                        rejectedProcessIds.Add(processId);
+                        return true;
+                    }
+                    acceptedProcessIds.Add(processId);
+                }
+                catch
+                {
+                    rejectedProcessIds.Add(processId);
+                    return true;
+                }
+            }
+
+            int width = rect.Right - rect.Left;
+            int height = rect.Bottom - rect.Top;
+            if (width <= 0 || height <= 0) return true;
+
+            StringBuilder title = new(512);
+            StringBuilder className = new(256);
+            _ = GetWindowText(windowHandle, title, title.Capacity);
+            _ = GetClassName(windowHandle, className, className.Capacity);
+            GameWindowSnapshot snapshot = new(processId, windowHandle, className.ToString(), title.ToString(), width,
+                height);
+            if (windowHandle == foregroundWindow) foreground = snapshot;
+            long area = (long)width * height;
+            if (area > largestArea)
+            {
+                largestArea = area;
+                largest = snapshot;
+            }
+            return true;
+        };
+
+        try
+        {
+            _ = EnumWindows(callback, 0);
+            return foreground ?? largest;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// 将目录规范化为带结尾分隔符的完整路径前缀，避免把兄弟目录（如game2）误判为子路径。
     /// </summary>
     public static string GetDirectoryPrefix(string directory)
@@ -112,14 +224,70 @@ public static class GameProcessDetector
 
     public static bool IsAlive(Process process)
     {
+        int processId = SafeGetId(process);
         try
         {
             return !process.HasExited;
         }
         catch
         {
-            return false;
+            // 管理员或受保护进程可能拒绝 Process.HasExited 请求的句柄，
+            // 即使进程仍然存在。此时回退到系统进程快照，不能把拒绝访问当成退出。
+            return IsProcessIdPresent(processId);
         }
+    }
+
+    /// <summary>
+    /// 不打开目标进程查询句柄，直接从系统进程快照判断 PID 是否存在。
+    /// 即使 <see cref="Process.HasExited"/> 或 <see cref="Process.WaitForExitAsync(CancellationToken)"/> 被拒绝也可使用。
+    /// </summary>
+    public static bool IsProcessIdPresent(int processId)
+    {
+        if (processId <= 0) return false;
+        try
+        {
+            Process[] candidates = Process.GetProcesses();
+            try
+            {
+                foreach (Process candidate in candidates)
+                    if (candidate.Id == processId) return true;
+                return false;
+            }
+            finally
+            {
+                foreach (Process candidate in candidates) candidate.Dispose();
+            }
+        }
+        catch
+        {
+            // 快照采集失败不能证明某个具体进程仍然存活。
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 等待进程退出；Windows 拒绝为管理员进程授予等待或查询句柄时，
+    /// 回退到 PID 快照轮询。
+    /// </summary>
+    public static async Task WaitForExitSafelyAsync(Process process, CancellationToken cancellationToken = default)
+    {
+        int processId = SafeGetId(process);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+            return;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // ShellExecute 代理和管理员目标进程可能不提供可等待句柄。
+        }
+
+        while (IsProcessIdPresent(processId))
+            await Task.Delay(1000, cancellationToken);
     }
 
     public static bool HasWindow(Process process)
@@ -134,6 +302,79 @@ public static class GameProcessDetector
         }
     }
 
+    /// <summary>
+    /// 获取进程位于前台的可见顶层窗口；没有前台窗口时回退到面积最大的可见窗口。
+    /// 这里通过 user32 枚举窗口，不打开进程查询句柄，因此仍可观察管理员权限游戏。
+    /// </summary>
+    public static GameWindowSnapshot? TryGetPrimaryWindowSnapshot(Process process)
+    {
+        int processId = SafeGetId(process);
+        if (processId <= 0) return null;
+
+        nint foregroundWindow = GetForegroundWindow();
+        GameWindowSnapshot? foreground = null;
+        GameWindowSnapshot? largest = null;
+        long largestArea = -1;
+        EnumWindowsProc callback = (windowHandle, _) =>
+        {
+            if (!IsWindowVisible(windowHandle)) return true;
+            GetWindowThreadProcessId(windowHandle, out uint windowProcessId);
+            if (windowProcessId != (uint)processId || !GetWindowRect(windowHandle, out NativeRect rect)) return true;
+
+            int width = rect.Right - rect.Left;
+            int height = rect.Bottom - rect.Top;
+            if (width <= 0 || height <= 0) return true;
+
+            StringBuilder title = new(512);
+            StringBuilder className = new(256);
+            _ = GetWindowText(windowHandle, title, title.Capacity);
+            _ = GetClassName(windowHandle, className, className.Capacity);
+            GameWindowSnapshot snapshot = new(processId, windowHandle, className.ToString(), title.ToString(), width,
+                height);
+            if (windowHandle == foregroundWindow) foreground = snapshot;
+            long area = (long)width * height;
+            if (area > largestArea)
+            {
+                largestArea = area;
+                largest = snapshot;
+            }
+            return true;
+        };
+
+        try
+        {
+            _ = EnumWindows(callback, 0);
+            return foreground ?? largest;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 当前台窗口所属进程的可执行文件位于安装目录内时返回该进程。
+    /// 返回的 <see cref="Process"/> 实例由调用方负责释放。
+    /// </summary>
+    public static Process? TryGetForegroundProcessInDirectory(string directoryPrefix)
+    {
+        nint windowHandle = GetForegroundWindow();
+        if (windowHandle == 0 || GetWindowThreadProcessId(windowHandle, out uint processId) == 0 || processId == 0)
+            return null;
+
+        try
+        {
+            Process process = Process.GetProcessById((int)processId);
+            if (IsInDirectory(process, directoryPrefix)) return process;
+            process.Dispose();
+        }
+        catch
+        {
+            // 从查询 PID 到打开进程之间，前台窗口可能已经消失。
+        }
+        return null;
+    }
+
     public static int SafeGetId(Process process)
     {
         try
@@ -146,9 +387,15 @@ public static class GameProcessDetector
         }
     }
 
+    /// <summary>
+    /// 判断进程的可执行文件是否位于指定目录前缀内。
+    /// </summary>
+    public static bool IsProcessInDirectory(Process process, string directoryPrefix) =>
+        IsInDirectory(process, directoryPrefix);
+
     private static bool IsInDirectory(Process process, string directoryPrefix)
     {
-        if (process.HasExited) return false;
+        if (!IsAlive(process)) return false;
         string? path = process.TryGetExecutablePath();
         return path is not null && path.StartsWith(directoryPrefix, StringComparison.OrdinalIgnoreCase);
     }

--- a/GalgameManager/Helpers/GameRuntimeProcessRelay.cs
+++ b/GalgameManager/Helpers/GameRuntimeProcessRelay.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 在同一次游戏启动中共享已经确认的正式游戏进程，避免各后台任务独立判断进程接力。
+/// </summary>
+public sealed class GameRuntimeProcessRelay
+{
+    private readonly object _syncRoot = new();
+    private readonly TaskCompletionSource<Process?> _firstConfirmation =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Process? _confirmedProcess;
+    private bool _completed;
+
+    /// <summary>
+    /// 当前已经确认的正式游戏进程；尚未确认时返回 <see langword="null"/>。
+    /// </summary>
+    public Process? ConfirmedProcess
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _confirmedProcess;
+        }
+    }
+
+    /// <summary>
+    /// 计时任务是否已经结束，不会再确认新的游戏进程。
+    /// </summary>
+    public bool IsCompleted
+    {
+        get
+        {
+            lock (_syncRoot)
+                return _completed;
+        }
+    }
+
+    /// <summary>
+    /// 发布由计时任务确认过的正式游戏进程。
+    /// </summary>
+    public void Confirm(Process process)
+    {
+        lock (_syncRoot)
+        {
+            if (_completed) return;
+            _confirmedProcess = process;
+            _firstConfirmation.TrySetResult(process);
+        }
+    }
+
+    /// <summary>
+    /// 等待第一个正式游戏进程；计时任务未确认进程便结束时返回 <see langword="null"/>。
+    /// </summary>
+    public Task<Process?> WaitForConfirmationAsync()
+    {
+        lock (_syncRoot)
+        {
+            if (_confirmedProcess is not null) return Task.FromResult<Process?>(_confirmedProcess);
+            if (_completed) return Task.FromResult<Process?>(null);
+            return _firstConfirmation.Task;
+        }
+    }
+
+    /// <summary>
+    /// 标记本次启动的进程跟踪已经结束。
+    /// </summary>
+    public void Complete()
+    {
+        lock (_syncRoot)
+        {
+            if (_completed) return;
+            _completed = true;
+            _firstConfirmation.TrySetResult(null);
+        }
+    }
+}

--- a/GalgameManager/Helpers/GameWindowTransitionGate.cs
+++ b/GalgameManager/Helpers/GameWindowTransitionGate.cs
@@ -1,0 +1,229 @@
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 用于区分启动弹窗和正式游戏窗口的可见顶层窗口快照。
+/// </summary>
+public readonly record struct GameWindowSnapshot(
+    int ProcessId,
+    nint WindowHandle,
+    string ClassName,
+    string Title,
+    int Width,
+    int Height)
+{
+    public bool IsUsable => ProcessId > 0 && WindowHandle != 0 && Width > 0 && Height > 0;
+}
+
+/// <summary>
+/// 启动窗口从首次出现到确认正式游戏的阶段。
+/// </summary>
+public enum GameWindowTransitionStage
+{
+    WaitingForBaseline,
+    WaitingForTransition,
+    ConfirmingGameplayWindow,
+    Ready,
+}
+
+/// <summary>
+/// 在观察到稳定且有意义的顶层窗口切换前保持预备计时状态。
+/// 此门控不依赖本地化窗口标题或可执行文件名。
+/// </summary>
+public sealed class GameWindowTransitionGate
+{
+    private const int RequiredStableSamples = 2;
+    private GameWindowSnapshot? _baseline;
+    private int _baselineSamples;
+    private GameWindowSnapshot? _candidate;
+    private int _candidateSamples;
+
+    public GameWindowTransitionStage Stage { get; private set; } = GameWindowTransitionStage.WaitingForBaseline;
+
+    public bool IsReady => Stage == GameWindowTransitionStage.Ready;
+
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        if (IsReady) return true;
+        if (!snapshot.HasValue || !snapshot.Value.IsUsable)
+        {
+            ResetCandidate();
+            return false;
+        }
+
+        GameWindowSnapshot current = snapshot.Value;
+        if (!_baseline.HasValue)
+        {
+            _baseline = current;
+            _baselineSamples = 1;
+            Stage = GameWindowTransitionStage.WaitingForBaseline;
+            return false;
+        }
+
+        bool sameBaselineWindow = IsSameWindowIdentity(_baseline.Value, current);
+        if (_baselineSamples < RequiredStableSamples)
+        {
+            if (sameBaselineWindow)
+            {
+                if (++_baselineSamples >= RequiredStableSamples)
+                    Stage = GameWindowTransitionStage.WaitingForTransition;
+            }
+            else
+            {
+                _baseline = current;
+                _baselineSamples = 1;
+                Stage = GameWindowTransitionStage.WaitingForBaseline;
+            }
+            ResetCandidate();
+            return false;
+        }
+
+        if (sameBaselineWindow)
+        {
+            ResetCandidate();
+            return false;
+        }
+
+        if (!_candidate.HasValue || !IsSameCandidate(_candidate.Value, current))
+        {
+            _candidate = current;
+            _candidateSamples = 1;
+            Stage = GameWindowTransitionStage.ConfirmingGameplayWindow;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        // 标准 Win32 对话框仍属于启动阶段。启动器先切到声明框时，不能把第一次窗口切换
+        // 直接当成正式游戏；将声明框提升为新基准后继续等待下一次非对话框切换。
+        if (IsStandardDialog(current))
+        {
+            _baseline = current;
+            _baselineSamples = RequiredStableSamples;
+            ResetCandidate();
+            return false;
+        }
+        Stage = GameWindowTransitionStage.Ready;
+        return true;
+    }
+
+    public static bool HasMeaningfulTransition(GameWindowSnapshot baseline, GameWindowSnapshot current)
+    {
+        if (!baseline.IsUsable || !current.IsUsable) return false;
+        return !IsSameWindowIdentity(baseline, current);
+    }
+
+    private static bool IsSameWindowIdentity(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal);
+
+    private static bool IsSameCandidate(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal) &&
+        string.Equals(left.Title.Trim(), right.Title.Trim(), StringComparison.Ordinal) &&
+        Math.Abs(left.Width - right.Width) < 16 &&
+        Math.Abs(left.Height - right.Height) < 16;
+
+    private static bool IsStandardDialog(GameWindowSnapshot snapshot) =>
+        string.Equals(snapshot.ClassName.Trim(), "#32770", StringComparison.Ordinal);
+
+    private void ResetCandidate()
+    {
+        _candidate = null;
+        _candidateSamples = 0;
+        if (_baselineSamples >= RequiredStableSamples)
+            Stage = GameWindowTransitionStage.WaitingForTransition;
+    }
+}
+
+/// <summary>
+/// 要求另一个前台进程连续保持稳定后，运行中的任务才接替到该进程。
+/// </summary>
+public sealed class StableProcessHandoffGate
+{
+    private const int RequiredStableSamples = 2;
+    private int _candidateProcessId;
+    private int _candidateSamples;
+
+    public bool Observe(int trackedProcessId, int? foregroundProcessId)
+    {
+        if (!foregroundProcessId.HasValue || foregroundProcessId.Value <= 0 ||
+            foregroundProcessId.Value == trackedProcessId)
+        {
+            Reset();
+            return false;
+        }
+
+        if (_candidateProcessId != foregroundProcessId.Value)
+        {
+            _candidateProcessId = foregroundProcessId.Value;
+            _candidateSamples = 1;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        Reset();
+        return true;
+    }
+
+    private void Reset()
+    {
+        _candidateProcessId = 0;
+        _candidateSamples = 0;
+    }
+}
+
+/// <summary>
+/// 直接启动的游戏窗口连续稳定两个采样周期后予以确认。
+/// 与 <see cref="GameWindowTransitionGate"/> 不同，此门控不要求先出现启动器到游戏的窗口切换。
+/// </summary>
+public sealed class StableGameWindowGate
+{
+    private const int RequiredStableSamples = 2;
+    private GameWindowSnapshot? _candidate;
+    private int _candidateSamples;
+
+    public bool Observe(GameWindowSnapshot? snapshot)
+    {
+        if (!snapshot.HasValue || !snapshot.Value.IsUsable)
+        {
+            Reset();
+            return false;
+        }
+
+        GameWindowSnapshot current = snapshot.Value;
+        if (!_candidate.HasValue || !IsSameWindow(_candidate.Value, current))
+        {
+            _candidate = current;
+            _candidateSamples = 1;
+            return false;
+        }
+
+        if (++_candidateSamples < RequiredStableSamples) return false;
+        Reset();
+        return true;
+    }
+
+    public void Reset()
+    {
+        _candidate = null;
+        _candidateSamples = 0;
+    }
+
+    private static bool IsSameWindow(GameWindowSnapshot left, GameWindowSnapshot right) =>
+        left.ProcessId == right.ProcessId &&
+        left.WindowHandle == right.WindowHandle &&
+        string.Equals(left.ClassName.Trim(), right.ClassName.Trim(), StringComparison.Ordinal) &&
+        Math.Abs(left.Width - right.Width) < 16 &&
+        Math.Abs(left.Height - right.Height) < 16;
+}
+
+public static class GameSessionExitPolicy
+{
+    /// <summary>
+    /// 只有尚未确认的启动阶段进程需要等待替代进程；已经确认的正式游戏 PID 退出后应立即结束。
+    /// </summary>
+    public static bool ShouldWaitForReplacement(bool recordingStarted, int confirmedGameplayProcessId,
+        int exitedProcessId) =>
+        !recordingStarted || confirmedGameplayProcessId <= 0 || confirmedGameplayProcessId != exitedProcessId;
+}

--- a/GalgameManager/Helpers/PlayTimeRecordingModeHelper.cs
+++ b/GalgameManager/Helpers/PlayTimeRecordingModeHelper.cs
@@ -1,0 +1,13 @@
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 解析一次游戏启动期间保持不变的游玩时间记录模式。
+/// </summary>
+public static class PlayTimeRecordingModeHelper
+{
+    /// <summary>
+    /// 已锁定的模式优先；旧任务若已经创建精确时段，则恢复为精确模式；其余情况读取当前设置。
+    /// </summary>
+    public static bool ResolvePreciseMode(bool? lockedMode, bool hasActiveSession, bool settingEnabled) =>
+        lockedMode ?? (hasActiveSession || settingEnabled);
+}

--- a/GalgameManager/Helpers/PlayTimeSessionHelper.cs
+++ b/GalgameManager/Helpers/PlayTimeSessionHelper.cs
@@ -1,0 +1,657 @@
+using GalgameManager.Core.Helpers;
+using GalgameManager.Models;
+
+namespace GalgameManager.Helpers;
+
+/// <summary>
+/// 保持原生精确时段与旧版逐日分钟兼容层一致。
+/// </summary>
+public static class PlayTimeSessionHelper
+{
+    public static long GetDaySeconds(Galgame game, DateTime date)
+    {
+        string key = date.Date.ToStringDefault();
+        if (game.PlayedTimeSeconds.TryGetValue(key, out long seconds)) return Math.Max(0, seconds);
+        return Math.Max(0, GetLegacyMinutes(game, date) * 60L);
+    }
+
+    public static int GetDayMinutes(Galgame game, DateTime date) => GetLegacyMinutes(game, date);
+
+    /// <summary>
+    /// 按旧版规则为指定日期增加一次整分钟采样，同时维护秒级兼容汇总。
+    /// 传入分钟级启动记录时，同时保存本次启动对柱状图分段的贡献；
+    /// 逐日总时长仍只增加一个整分钟，不会因此获得秒级精度。
+    /// </summary>
+    public static void AddLegacyMinuteSample(
+        Galgame game,
+        DateTime date,
+        PlayTimeSession? minuteSession = null)
+    {
+        string key = date.Date.ToStringDefault();
+        EnsureSecondBucket(game, date.Date, key);
+        long currentSeconds = Math.Max(0, game.PlayedTimeSeconds[key]);
+        long updatedSeconds = currentSeconds > long.MaxValue - 60 ? long.MaxValue : currentSeconds + 60;
+        game.PlayedTimeSeconds[key] = updatedSeconds;
+        game.PlayedTime[key] = checked((int)Math.Min(int.MaxValue, updatedSeconds / 60));
+        long totalMinutes = game.PlayedTime.Values.Sum(value => (long)Math.Max(0, value));
+        game.TotalPlayTime = checked((int)Math.Min(int.MaxValue, totalMinutes));
+
+        if (minuteSession is null) return;
+        minuteSession.SampledMinutesByDay ??= new Dictionary<string, int>();
+        int currentMinutes = minuteSession.SampledMinutesByDay.TryGetValue(key, out int value)
+            ? Math.Max(0, value)
+            : 0;
+        minuteSession.SampledMinutesByDay[key] = currentMinutes == int.MaxValue
+            ? int.MaxValue
+            : currentMinutes + 1;
+        if (minuteSession.EndedAt < date) minuteSession.EndedAt = date;
+    }
+
+    /// <summary>
+    /// 返回指定日期内由分钟级启动记录贡献的各段信息。
+    /// 旧数据和手工补差不属于任何启动，因此不会出现在结果中。
+    /// </summary>
+    public static IReadOnlyList<MinutePlayTimeDaySegment> GetMinuteSampleSegmentsForDay(
+        Galgame game,
+        DateTime date)
+    {
+        DateTime dayStart = date.Date;
+        DateTime dayEnd = dayStart.AddDays(1);
+        return game.PlayTimeSessions
+            .Where(session => session.Kind == PlayTimeSessionKind.MinuteSampled)
+            .OrderBy(session => session.StartedAt)
+            .Select(session => new MinutePlayTimeDaySegment(
+                session.Id,
+                dayStart,
+                session.StartedAt > dayStart ? session.StartedAt : dayStart,
+                session.EndedAt < dayEnd ? session.EndedAt : dayEnd,
+                GetMinuteSamplesForDay(session, dayStart),
+                session.IsOpen,
+                session.SampledMinutesByDay?.Count(pair => pair.Value > 0) > 1))
+            .Where(segment => segment.Minutes > 0)
+            .ToArray();
+    }
+
+    public static IReadOnlyList<long> GetMinuteSampleDurationsForDay(Galgame game, DateTime date) =>
+        GetMinuteSampleSegmentsForDay(game, date)
+            .Select(segment => segment.Minutes * 60L)
+            .ToArray();
+
+    /// <summary>
+    /// 返回所有秒级启动记录按日期拆分后的片段。
+    /// 分钟界面与秒级界面共用这份投影，避免秒级启动记录在分钟界面被并入历史余量。
+    /// </summary>
+    public static IReadOnlyList<PlayTimeDaySegment> GetPreciseSessionDaySegments(Galgame game) =>
+        game.PlayTimeSessions
+            .Where(session => session.Kind != PlayTimeSessionKind.MinuteSampled)
+            .SelectMany(SplitSessionByDay)
+            .OrderBy(segment => segment.Date)
+            .ThenBy(segment => segment.StartedAt)
+            .ToArray();
+
+    public static long GetMinuteSampleSecondsForDay(Galgame game, DateTime date)
+    {
+        long result = 0;
+        foreach (MinutePlayTimeDaySegment segment in GetMinuteSampleSegmentsForDay(game, date))
+        {
+            long seconds = segment.Minutes * 60L;
+            if (result > long.MaxValue - seconds) return long.MaxValue;
+            result += seconds;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// 将指定日期的汇总拆分为精确启动记录、分钟模式启动记录和无边界余量。
+    /// 分钟模式启动记录只提供整分钟贡献，不会被误当成历史或手工补差。
+    /// </summary>
+    public static PlayTimeDayBreakdown GetDayDisplayBreakdown(Galgame game, DateTime date)
+    {
+        DateTime day = date.Date;
+        long totalSeconds = GetDaySeconds(game, day);
+        long preciseSessionSeconds = 0;
+        foreach (PlayTimeSession session in game.PlayTimeSessions.Where(session =>
+                     session.Kind != PlayTimeSessionKind.MinuteSampled && session.CountsTowardPlayTime))
+        {
+            foreach (PlayTimeDaySegment segment in SplitSessionByDay(session).Where(segment => segment.Date == day))
+                preciseSessionSeconds = SaturatingAdd(preciseSessionSeconds, segment.DurationSeconds);
+        }
+
+        long availableAfterPreciseSessions = Math.Max(0, totalSeconds - preciseSessionSeconds);
+        long minuteSampleSeconds = Math.Min(availableAfterPreciseSessions,
+            GetMinuteSampleSecondsForDay(game, day));
+        long unsegmentedSeconds = Math.Max(0, availableAfterPreciseSessions - minuteSampleSeconds);
+        return new PlayTimeDayBreakdown(
+            totalSeconds,
+            preciseSessionSeconds,
+            minuteSampleSeconds,
+            unsegmentedSeconds);
+    }
+
+    /// <summary>
+    /// 修改某次启动在指定日期贡献的整分钟数，并保留当天未归入启动记录的汇总余量。
+    /// </summary>
+    public static bool ReplaceMinuteSampleSegment(
+        Galgame game,
+        Guid sessionId,
+        DateTime date,
+        int minutes)
+    {
+        PlayTimeSession? session = game.PlayTimeSessions.FirstOrDefault(item =>
+            item.Id == sessionId && item.Kind == PlayTimeSessionKind.MinuteSampled);
+        if (session is null || session.IsOpen) return false;
+
+        DateTime day = date.Date;
+        int normalizedMinutes = Math.Max(0, minutes);
+        int previousMinutes = GetMinuteSamplesForDay(session, day);
+        long sampledSeconds = GetMinuteSampleSecondsForDay(game, day);
+        long unsegmentedSeconds = Math.Max(0, GetDaySeconds(game, day) - sampledSeconds);
+
+        SetMinuteSamplesForDay(session, day, normalizedMinutes);
+        if (!HasMinuteSamples(session)) game.PlayTimeSessions.Remove(session);
+
+        long remainingSampledSeconds = Math.Max(0, sampledSeconds - previousMinutes * 60L);
+        long replacementSeconds = normalizedMinutes * 60L;
+        long newTotal = SaturatingAdd(unsegmentedSeconds,
+            SaturatingAdd(remainingSampledSeconds, replacementSeconds));
+        SetDaySeconds(game, day, newTotal);
+        RefreshDerivedState(game);
+        return true;
+    }
+
+    public static bool HasMinuteSamples(PlayTimeSession session) =>
+        session.SampledMinutesByDay?.Values.Any(value => value > 0) == true;
+
+    public static long GetTotalSeconds(Galgame game)
+    {
+        HashSet<DateTime> dates = game.PlayedTime.Keys
+            .Select(Utils.TryParseDateGuessCulture)
+            .Where(date => date.Year > 1900)
+            .Select(date => date.Date)
+            .ToHashSet();
+        foreach (string key in game.PlayedTimeSeconds.Keys)
+        {
+            DateTime date = Utils.TryParseDateGuessCulture(key);
+            if (date.Year > 1900) dates.Add(date.Date);
+        }
+        return dates.Aggregate(0L, (total, date) =>
+            SaturatingAdd(total, GetDaySeconds(game, date)));
+    }
+
+    public static void AddInterval(Galgame game, DateTime start, DateTime end)
+        => ApplyIntervalDelta(game, start, end, 1);
+
+    public static void RemoveInterval(Galgame game, DateTime start, DateTime end)
+        => ApplyIntervalDelta(game, start, end, -1);
+
+    public static void AddSession(Galgame game, PlayTimeSession session)
+    {
+        if (game.PlayTimeSessions.Any(item => item.Id == session.Id))
+            throw new InvalidOperationException("The play-time session already exists.");
+        if (HasOverlappingSession(game, session))
+            throw new InvalidOperationException("The play-time session overlaps an existing session.");
+        if (session.CountsTowardPlayTime) ApplySessionDeltaCore(game, session, 1);
+        game.PlayTimeSessions.Add(session);
+        RefreshDerivedState(game);
+    }
+
+    public static void ReplaceSession(Galgame game, PlayTimeSession original, PlayTimeSession replacement)
+    {
+        int index = game.PlayTimeSessions.FindIndex(session => session.Id == original.Id);
+        if (index < 0) throw new InvalidOperationException("The play-time session no longer exists.");
+        if (HasOverlappingSession(game, replacement))
+            throw new InvalidOperationException("The play-time session overlaps an existing session.");
+
+        if (original.CountsTowardPlayTime) ApplySessionDeltaCore(game, original, -1);
+        if (replacement.CountsTowardPlayTime) ApplySessionDeltaCore(game, replacement, 1);
+
+        replacement.Id = original.Id;
+        game.PlayTimeSessions[index] = replacement;
+        RefreshDerivedState(game);
+    }
+
+    public static bool DeleteSession(Galgame game, Guid sessionId)
+    {
+        int index = game.PlayTimeSessions.FindIndex(session => session.Id == sessionId);
+        if (index < 0) return false;
+        PlayTimeSession session = game.PlayTimeSessions[index];
+        if (session.IsOpen) return false;
+        if (session.CountsTowardPlayTime) ApplySessionDeltaCore(game, session, -1);
+        game.PlayTimeSessions.RemoveAt(index);
+        RefreshDerivedState(game);
+        return true;
+    }
+
+    /// <summary>
+    /// 将旧格式时段转换为显式计时片段。转换只改变表示方式，不改变累计时长。
+    /// </summary>
+    public static void EnsureExplicitActivityIntervals(PlayTimeSession session)
+    {
+        if (session.ActivityIntervals is not null) return;
+        session.ActivityIntervals = [];
+        if (session.EndedAt > session.StartedAt)
+        {
+            session.ActivityIntervals.Add(new PlayTimeActivityInterval
+            {
+                StartedAt = session.StartedAt,
+                EndedAt = session.EndedAt,
+            });
+        }
+    }
+
+    public static PlayTimeActivityInterval BeginActivityInterval(PlayTimeSession session, DateTime startedAt)
+    {
+        EnsureExplicitActivityIntervals(session);
+        PlayTimeActivityInterval interval = new()
+        {
+            StartedAt = startedAt,
+            EndedAt = startedAt,
+        };
+        session.ActivityIntervals!.Add(interval);
+        if (session.EndedAt < startedAt) session.EndedAt = startedAt;
+        return interval;
+    }
+
+    /// <summary>
+    /// 延长单次启动中的当前有效计时片段，并返回本次增加到逐日汇总中的秒数。
+    /// 外层时段始终保持一条，前后台切换只会新增内部片段。
+    /// </summary>
+    public static long ExtendActivityInterval(Galgame game, PlayTimeSession session,
+        PlayTimeActivityInterval interval, DateTime endedAt)
+    {
+        if (endedAt <= interval.EndedAt || endedAt <= interval.StartedAt) return 0;
+
+        long previousSeconds = session.CountsTowardPlayTime
+            ? GetIntervalSeconds(interval.StartedAt, interval.EndedAt)
+            : 0;
+        if (session.CountsTowardPlayTime)
+            ApplyIntervalDeltaCore(game, interval.StartedAt, interval.EndedAt, -1);
+
+        interval.EndedAt = endedAt;
+        if (session.EndedAt < endedAt) session.EndedAt = endedAt;
+
+        long currentSeconds = session.CountsTowardPlayTime
+            ? GetIntervalSeconds(interval.StartedAt, interval.EndedAt)
+            : 0;
+        if (session.CountsTowardPlayTime)
+            ApplyIntervalDeltaCore(game, interval.StartedAt, interval.EndedAt, 1);
+        RefreshDerivedState(game);
+        return Math.Max(0, currentSeconds - previousSeconds);
+    }
+
+    public static long GetSessionDurationSeconds(PlayTimeSession session) =>
+        GetEffectiveActivityIntervals(session)
+            .Aggregate(0L, (total, interval) =>
+                SaturatingAdd(total, GetIntervalSeconds(interval.StartedAt, interval.EndedAt)));
+
+    public static bool HasOverlappingSession(Galgame game, PlayTimeSession candidate)
+    {
+        if (candidate.EndedAt <= candidate.StartedAt) return false;
+        return game.PlayTimeSessions.Any(existing =>
+            existing.Id != candidate.Id &&
+            existing.EndedAt > existing.StartedAt &&
+            candidate.StartedAt < existing.EndedAt &&
+            candidate.EndedAt > existing.StartedAt);
+    }
+
+    /// <summary>
+    /// 获取单次启动在指定日期内的有效计时片段，并将跨日片段裁剪到当天边界。
+    /// </summary>
+    public static IReadOnlyList<PlayTimeActivityInterval> GetActivityIntervalsForDay(
+        PlayTimeSession session, DateTime date)
+    {
+        DateTime dayStart = date.Date;
+        DateTime dayEnd = dayStart.AddDays(1);
+        return GetEffectiveActivityIntervals(session)
+            .Select(interval => new PlayTimeActivityInterval
+            {
+                StartedAt = interval.StartedAt > dayStart ? interval.StartedAt : dayStart,
+                EndedAt = interval.EndedAt < dayEnd ? interval.EndedAt : dayEnd,
+            })
+            .Where(interval => interval.EndedAt > interval.StartedAt)
+            .OrderBy(interval => interval.StartedAt)
+            .ToArray();
+    }
+
+    public static bool CloseOpenSession(Galgame game, Guid sessionId)
+    {
+        PlayTimeSession? session = game.PlayTimeSessions.FirstOrDefault(item => item.Id == sessionId);
+        if (session is null || !session.IsOpen) return false;
+        session.IsOpen = false;
+        if (session.EndedAt < session.StartedAt) session.EndedAt = session.StartedAt;
+        RefreshDerivedState(game);
+        return true;
+    }
+
+    public static IReadOnlyList<PlayTimeDaySegment> SplitSessionByDay(PlayTimeSession session)
+    {
+        List<ActivityDaySlice> slices = GetEffectiveActivityIntervals(session)
+            .SelectMany(SplitActivityByDay)
+            .ToList();
+        if (slices.Count == 0)
+        {
+            return
+            [
+                new PlayTimeDaySegment(
+                    session.Id,
+                    session.StartedAt.Date,
+                    session.StartedAt,
+                    session.EndedAt < session.StartedAt ? session.StartedAt : session.EndedAt,
+                    0,
+                    session.IsOpen,
+                    session.Kind,
+                    session.CountsTowardPlayTime),
+            ];
+        }
+
+        List<PlayTimeDaySegment> result = [];
+        foreach (IGrouping<DateTime, ActivityDaySlice> group in slices.GroupBy(slice => slice.Date))
+        {
+            DateTime date = group.Key;
+            DateTime displayedStart = session.StartedAt > date ? session.StartedAt : date;
+            DateTime displayedEnd = session.EndedAt < date.AddDays(1) ? session.EndedAt : date.AddDays(1);
+            if (displayedEnd < displayedStart)
+            {
+                displayedStart = group.Min(slice => slice.StartedAt);
+                displayedEnd = group.Max(slice => slice.EndedAt);
+            }
+            result.Add(new PlayTimeDaySegment(
+                session.Id,
+                date,
+                displayedStart,
+                displayedEnd,
+                group.Aggregate(0L, (total, slice) => SaturatingAdd(total, slice.DurationSeconds)),
+                session.IsOpen,
+                session.Kind,
+                session.CountsTowardPlayTime));
+        }
+        return result;
+    }
+
+    public static bool RefreshDerivedState(Galgame game)
+    {
+        bool changed = false;
+        foreach ((string key, long value) in game.PlayedTimeSeconds.ToArray())
+        {
+            long seconds = Math.Max(0, value);
+            if (seconds == 0)
+            {
+                changed = true;
+                game.PlayedTimeSeconds.Remove(key);
+                game.PlayedTime.Remove(key);
+                continue;
+            }
+
+            int minutes = checked((int)Math.Min(int.MaxValue, seconds / 60));
+            if (minutes > 0)
+            {
+                if (!game.PlayedTime.TryGetValue(key, out int currentMinutes) || currentMinutes != minutes)
+                {
+                    game.PlayedTime[key] = minutes;
+                    changed = true;
+                }
+            }
+            else if (game.PlayedTime.Remove(key))
+            {
+                changed = true;
+            }
+        }
+
+        long totalMinutes = game.PlayedTime.Values.Aggregate(0L, (total, minutes) =>
+            SaturatingAdd(total, Math.Max(0, minutes)));
+        int totalPlayTime = checked((int)Math.Min(int.MaxValue, totalMinutes));
+        if (game.TotalPlayTime != totalPlayTime)
+        {
+            game.TotalPlayTime = totalPlayTime;
+            changed = true;
+        }
+        DateTime latestSession = game.PlayTimeSessions
+            .Where(session => session.EndedAt >= session.StartedAt)
+            .Select(session => session.EndedAt)
+            .DefaultIfEmpty(DateTime.MinValue)
+            .Max();
+        DateTime latestLegacy = game.PlayedTime.Keys
+            .Select(Utils.TryParseDateGuessCulture)
+            .DefaultIfEmpty(DateTime.MinValue)
+            .Max();
+        DateTime lastPlayTime = latestSession > latestLegacy ? latestSession : latestLegacy;
+        if (game.LastPlayTime != lastPlayTime)
+        {
+            game.LastPlayTime = lastPlayTime;
+            changed = true;
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// 校正旧数据中逐日汇总小于原生计入时段之和的情况，并刷新分钟兼容层。
+    /// 该操作需要遍历全部时段，只应在载入详情或执行显式编辑时调用。
+    /// </summary>
+    public static bool ReconcileCountedSessionTotals(Galgame game)
+    {
+        bool changed = EnsureCountedSessionMinimums(game);
+        return RefreshDerivedState(game) || changed;
+    }
+
+    private static void ApplyIntervalDelta(Galgame game, DateTime start, DateTime end, int sign)
+    {
+        ApplyIntervalDeltaCore(game, start, end, sign);
+        RefreshDerivedState(game);
+    }
+
+    private static void ApplyIntervalDeltaCore(Galgame game, DateTime start, DateTime end, int sign)
+    {
+        if (end <= start) return;
+        DateTime cursor = start;
+        int safety = 0;
+        while (cursor < end && safety++ < 3660)
+        {
+            DateTime dayEnd = cursor.Date.AddDays(1);
+            DateTime segmentEnd = end < dayEnd ? end : dayEnd;
+            long seconds = Math.Max(0,
+                (long)Math.Round((segmentEnd - cursor).TotalSeconds, MidpointRounding.AwayFromZero));
+            if (seconds > 0)
+            {
+                string key = cursor.Date.ToStringDefault();
+                EnsureSecondBucket(game, cursor.Date, key);
+                long currentSeconds = Math.Max(0, game.PlayedTimeSeconds[key]);
+                game.PlayedTimeSeconds[key] = sign > 0
+                    ? SaturatingAdd(currentSeconds, seconds)
+                    : Math.Max(0, currentSeconds - seconds);
+            }
+            cursor = segmentEnd;
+        }
+    }
+
+    private static void ApplySessionDeltaCore(Galgame game, PlayTimeSession session, int sign)
+    {
+        foreach (PlayTimeActivityInterval interval in GetEffectiveActivityIntervals(session))
+            ApplyIntervalDeltaCore(game, interval.StartedAt, interval.EndedAt, sign);
+    }
+
+    private static IReadOnlyList<PlayTimeActivityInterval> GetEffectiveActivityIntervals(
+        PlayTimeSession session)
+    {
+        if (session.ActivityIntervals is not null)
+            return session.ActivityIntervals
+                .Where(interval => interval.EndedAt > interval.StartedAt)
+                .ToArray();
+        if (session.EndedAt <= session.StartedAt) return [];
+        return
+        [
+            new PlayTimeActivityInterval
+            {
+                StartedAt = session.StartedAt,
+                EndedAt = session.EndedAt,
+            },
+        ];
+    }
+
+    private static IEnumerable<ActivityDaySlice> SplitActivityByDay(PlayTimeActivityInterval interval)
+    {
+        DateTime cursor = interval.StartedAt;
+        int safety = 0;
+        while (cursor < interval.EndedAt && safety++ < 3660)
+        {
+            DateTime dayEnd = cursor.Date.AddDays(1);
+            DateTime segmentEnd = interval.EndedAt < dayEnd ? interval.EndedAt : dayEnd;
+            yield return new ActivityDaySlice(
+                cursor.Date,
+                cursor,
+                segmentEnd,
+                Math.Max(0, (long)Math.Round(
+                    (segmentEnd - cursor).TotalSeconds,
+                    MidpointRounding.AwayFromZero)));
+            cursor = segmentEnd;
+        }
+    }
+
+    private static long GetIntervalSeconds(DateTime start, DateTime end)
+    {
+        if (end <= start) return 0;
+        long result = 0;
+        DateTime cursor = start;
+        int safety = 0;
+        while (cursor < end && safety++ < 3660)
+        {
+            DateTime dayEnd = cursor.Date.AddDays(1);
+            DateTime segmentEnd = end < dayEnd ? end : dayEnd;
+            result += Math.Max(0,
+                (long)Math.Round((segmentEnd - cursor).TotalSeconds, MidpointRounding.AwayFromZero));
+            cursor = segmentEnd;
+        }
+        return result;
+    }
+
+    private static bool EnsureCountedSessionMinimums(Galgame game)
+    {
+        bool changed = false;
+        Dictionary<DateTime, long> minimums = [];
+        foreach (PlayTimeSession session in game.PlayTimeSessions)
+        {
+            if (session.Kind == PlayTimeSessionKind.MinuteSampled)
+            {
+                if (session.SampledMinutesByDay is null) continue;
+                foreach ((string key, int minutes) in session.SampledMinutesByDay)
+                {
+                    DateTime date = Utils.TryParseDateGuessCulture(key);
+                    if (date.Year <= 1900 || minutes <= 0) continue;
+                    AddMinimum(date.Date, minutes * 60L);
+                }
+                continue;
+            }
+
+            if (!session.CountsTowardPlayTime) continue;
+            foreach (PlayTimeDaySegment segment in SplitSessionByDay(session))
+                AddMinimum(segment.Date, segment.DurationSeconds);
+        }
+
+        foreach ((DateTime date, long minimumSeconds) in minimums)
+        {
+            string key = date.ToStringDefault();
+            if (EnsureSecondBucket(game, date, key)) changed = true;
+            long currentSeconds = Math.Max(0, game.PlayedTimeSeconds[key]);
+            if (currentSeconds >= minimumSeconds) continue;
+            game.PlayedTimeSeconds[key] = minimumSeconds;
+            changed = true;
+        }
+        return changed;
+
+        void AddMinimum(DateTime date, long seconds)
+        {
+            minimums.TryGetValue(date, out long current);
+            minimums[date] = SaturatingAdd(current, Math.Max(0, seconds));
+        }
+    }
+
+    private static bool EnsureSecondBucket(Galgame game, DateTime date, string key)
+    {
+        if (game.PlayedTimeSeconds.ContainsKey(key)) return false;
+        int legacyMinutes = GetLegacyMinutes(game, date);
+        string[] alternateKeys = game.PlayedTime.Keys
+            .Where(existingKey => !string.Equals(existingKey, key, StringComparison.Ordinal) &&
+                                  Utils.TryParseDateGuessCulture(existingKey).Date == date.Date)
+            .ToArray();
+        foreach (string alternateKey in alternateKeys) game.PlayedTime.Remove(alternateKey);
+        game.PlayedTimeSeconds[key] = Math.Max(0, legacyMinutes * 60L);
+        return true;
+    }
+
+    private static int GetLegacyMinutes(Galgame game, DateTime date)
+    {
+        string normalizedKey = date.Date.ToStringDefault();
+        if (game.PlayedTime.TryGetValue(normalizedKey, out int direct)) return Math.Max(0, direct);
+        int result = 0;
+        foreach ((string key, int value) in game.PlayedTime)
+        {
+            if (Utils.TryParseDateGuessCulture(key).Date == date.Date)
+                result = Math.Max(result, Math.Max(0, value));
+        }
+        return result;
+    }
+
+    private static int GetMinuteSamplesForDay(PlayTimeSession session, DateTime date)
+    {
+        if (session.SampledMinutesByDay is null) return 0;
+        long result = 0;
+        foreach ((string key, int value) in session.SampledMinutesByDay)
+        {
+            if (Utils.TryParseDateGuessCulture(key).Date != date.Date) continue;
+            result += Math.Max(0, value);
+        }
+        return checked((int)Math.Min(int.MaxValue, result));
+    }
+
+    private static void SetMinuteSamplesForDay(PlayTimeSession session, DateTime date, int minutes)
+    {
+        session.SampledMinutesByDay ??= new Dictionary<string, int>();
+        string[] matchingKeys = session.SampledMinutesByDay.Keys
+            .Where(key => Utils.TryParseDateGuessCulture(key).Date == date.Date)
+            .ToArray();
+        foreach (string key in matchingKeys) session.SampledMinutesByDay.Remove(key);
+        if (minutes > 0) session.SampledMinutesByDay[date.Date.ToStringDefault()] = minutes;
+    }
+
+    private static void SetDaySeconds(Galgame game, DateTime date, long seconds)
+    {
+        string[] matchingKeys = game.PlayedTimeSeconds.Keys
+            .Where(key => Utils.TryParseDateGuessCulture(key).Date == date.Date)
+            .ToArray();
+        foreach (string key in matchingKeys) game.PlayedTimeSeconds.Remove(key);
+        if (seconds > 0) game.PlayedTimeSeconds[date.Date.ToStringDefault()] = seconds;
+    }
+
+    private static long SaturatingAdd(long left, long right) =>
+        left > long.MaxValue - right ? long.MaxValue : left + right;
+}
+
+internal readonly record struct ActivityDaySlice(
+    DateTime Date,
+    DateTime StartedAt,
+    DateTime EndedAt,
+    long DurationSeconds);
+
+public readonly record struct PlayTimeDaySegment(
+    Guid SessionId,
+    DateTime Date,
+    DateTime StartedAt,
+    DateTime EndedAt,
+    long DurationSeconds,
+    bool IsOpen,
+    PlayTimeSessionKind Kind,
+    bool CountsTowardPlayTime);
+
+public readonly record struct MinutePlayTimeDaySegment(
+    Guid SessionId,
+    DateTime Date,
+    DateTime StartedAt,
+    DateTime EndedAt,
+    int Minutes,
+    bool IsOpen,
+    bool SpansMultipleDays);
+
+public readonly record struct PlayTimeDayBreakdown(
+    long TotalSeconds,
+    long PreciseSessionSeconds,
+    long MinuteSampleSeconds,
+    long UnsegmentedSeconds);

--- a/GalgameManager/Models/BgTasks/CallMagpieTask.cs
+++ b/GalgameManager/Models/BgTasks/CallMagpieTask.cs
@@ -15,13 +15,28 @@ public class CallMagpieTask : BgTaskBase
     public string ProcessName { get; set; } = null!;
     public bool HashFinished { get; set; }
     private Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
 
-    public CallMagpieTask() { } // Just for serialization
+    public CallMagpieTask() { } // 仅用于后台任务序列化恢复
 
     public CallMagpieTask(Galgame game, Process process)
+        : this(game, process, null)
+    {
+    }
+
+    public CallMagpieTask(Galgame game, Process process, GameRuntimeProcessRelay? processRelay)
     {
         Galgame = game;
         _process = process;
+        _processRelay = processRelay;
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器退出后仍等待计时任务发布正式游戏进程。
+        }
     }
     
     protected async override Task RecoverFromJsonInternal()
@@ -38,13 +53,30 @@ public class CallMagpieTask : BgTaskBase
             _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
             if (_process is null) throw new PvnException("Process not found");
         }
+        if (_processRelay is not null)
+        {
+            Process? confirmed = await _processRelay.WaitForConfirmationAsync();
+            if (confirmed is null || !GameProcessDetector.IsAlive(confirmed) || HashFinished)
+            {
+                ChangeProgress(1, 1, string.Empty, false);
+                return;
+            }
+            _process = confirmed;
+        }
         var magpiePath = await App.GetService<ILocalSettingsService>().ReadSettingAsync<string>(KeyValues.MagpiePath);
         if (string.IsNullOrEmpty(magpiePath)) throw new PvnException("CallMagpieTask_NoMagpiePath".GetLocalized());
         ChangeProgress(0, 1, "CallMagpieTask_LaunchingMagpie".GetLocalized());
         await MagpieHelper.LaunchMagpieAsync(magpiePath);
 
-        if (_process.HasExited || HashFinished) return;
-        ProcessName = _process.ProcessName;
+        if (!GameProcessDetector.IsAlive(_process) || HashFinished) return;
+        try
+        {
+            ProcessName = _process.ProcessName;
+        }
+        catch
+        {
+            // 受保护进程可能拒绝读取名称，仍继续尝试通过窗口调用 Magpie。
+        }
         for (var retry = 0; retry < MaxRetryCount && !HashFinished; retry++)
         {
             try
@@ -127,10 +159,10 @@ public static class MagpieHelper
         List<int> shortcuts = App.GetService<ILocalSettingsService>()
             .ReadSettingAsync<List<int>>(KeyValues.MagpieHotkeys).Result ?? [];
         InputSimulator keyboard = new();
-        // Press down all keys in the shortcut
+        // 依次按下快捷键。
         foreach (var shortcut in shortcuts)
             keyboard.Keyboard.KeyDown((VirtualKeyCode)shortcut);
-        // Release all keys in the shortcut (in reverse order is a common practice, though not strictly necessary for all cases)
+        // 按相反顺序释放快捷键。
         for (var i = shortcuts.Count - 1; i >= 0; i--)
             keyboard.Keyboard.KeyUp((VirtualKeyCode)shortcuts[i]);
     }

--- a/GalgameManager/Models/BgTasks/GameMuteTask.cs
+++ b/GalgameManager/Models/BgTasks/GameMuteTask.cs
@@ -11,15 +11,21 @@ public class GameMuteTask : BgTaskBase
     public int ProcessId { get; set; }
     public bool IsMuted { get; set; }
     private Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
 
-    public GameMuteTask() { } // For serialization
+    public GameMuteTask() { } // 仅用于后台任务序列化恢复
 
     public GameMuteTask(Galgame game, Process process)
+        : this(game, process, null)
+    {
+    }
+
+    public GameMuteTask(Galgame game, Process process, GameRuntimeProcessRelay? processRelay)
     {
         Galgame = game;
         _process = process;
-        ProcessName = process.ProcessName;
-        ProcessId = process.Id;
+        _processRelay = processRelay;
+        UpdateProcessIdentity(process);
     }
 
     protected override Task RecoverFromJsonInternal()
@@ -30,7 +36,7 @@ public class GameMuteTask : BgTaskBase
         }
         catch
         {
-            // Process might have exited, try to find by name
+            // 进程可能已经退出，回退到按名称查找。
             _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
         }
         return Task.CompletedTask;
@@ -42,19 +48,28 @@ public class GameMuteTask : BgTaskBase
         ChangeProgress(0, 1, "GameMuteTask_Starting".GetLocalized(Galgame.Name.Value!));
         
         // 确保开始时取消静音，防止上次异常退出导致的残留
-        AudioHelper.UnmuteProcess(_process.Id);
-        
-        while (!_process!.HasExited)
+        if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+
+        while (true)
         {
+            TryFollowConfirmedProcess();
+            Process? current = _process;
+            if (current is null || !GameProcessDetector.IsAlive(current))
+            {
+                if (_processRelay is null || _processRelay.IsCompleted) break;
+                await Task.Delay(200);
+                continue;
+            }
+
             try
             {
-                var shouldMute = !_process.IsMainWindowFocused();
+                bool shouldMute = !current.IsMainWindowFocused();
                 if (shouldMute)
                 {
                     // 需要静音
                     if (!IsMuted)
                     {
-                        if (AudioHelper.MuteProcess(_process.Id))
+                        if (AudioHelper.MuteProcess(current.Id))
                         {
                             IsMuted = true;
                             ChangeProgress(0, 1, "GameMuteTask_Muted".GetLocalized(Galgame.Name.Value!));
@@ -65,9 +80,9 @@ public class GameMuteTask : BgTaskBase
                 {
                     // 需要有声音 (在前台)
                     // 检查 IsMuted 标记或者系统实际状态
-                    if (IsMuted || AudioHelper.IsProcessMuted(_process.Id))
+                    if (IsMuted || AudioHelper.IsProcessMuted(current.Id))
                     {
-                        if (AudioHelper.UnmuteProcess(_process.Id))
+                        if (AudioHelper.UnmuteProcess(current.Id))
                         {
                             IsMuted = false;
                             ChangeProgress(0, 1, "GameMuteTask_Unmuted".GetLocalized(Galgame.Name.Value!));
@@ -87,8 +102,50 @@ public class GameMuteTask : BgTaskBase
         }
         
         // 结束时尝试取消静音
-        try { AudioHelper.UnmuteProcess(_process.Id); } catch { /* ignore */ }
+        try
+        {
+            if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+        }
+        catch
+        {
+            // 进程可能已退出，结束清理无需继续抛出异常。
+        }
         ChangeProgress(1, 1, string.Empty, false);
+    }
+
+    private void TryFollowConfirmedProcess()
+    {
+        Process? confirmed = _processRelay?.ConfirmedProcess;
+        if (confirmed is null || !GameProcessDetector.IsAlive(confirmed)) return;
+        int confirmedProcessId = GameProcessDetector.SafeGetId(confirmed);
+        if (confirmedProcessId <= 0 || confirmedProcessId == ProcessId) return;
+
+        try
+        {
+            if (ProcessId > 0) AudioHelper.UnmuteProcess(ProcessId);
+        }
+        catch
+        {
+            // 原启动器可能已经退出，切换进程时无需保留其静音状态。
+        }
+
+        _process = confirmed;
+        IsMuted = false;
+        UpdateProcessIdentity(confirmed);
+        AudioHelper.UnmuteProcess(ProcessId);
+    }
+
+    private void UpdateProcessIdentity(Process process)
+    {
+        ProcessId = GameProcessDetector.SafeGetId(process);
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器可能在任务创建前退出，稍后仍可接力到正式游戏进程。
+        }
     }
 
     public override string Title => "GameMuteTask_Title".GetLocalized();
@@ -105,7 +162,7 @@ public static class AudioHelper
     [DllImport("ole32.dll")]
     private static extern void CoUninitialize();
 
-    // Windows Core Audio API interfaces
+    // Windows Core Audio API 接口
     [ComImport]
     [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
     private class MMDeviceEnumerator

--- a/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
+++ b/GalgameManager/Models/BgTasks/IDeduplicatedBgTask.cs
@@ -1,0 +1,12 @@
+namespace GalgameManager.Models.BgTasks;
+
+/// <summary>
+/// 标记活动期间必须保持逻辑唯一的后台任务。
+/// </summary>
+public interface IDeduplicatedBgTask
+{
+    /// <summary>
+    /// 获取任务类型内的逻辑标识；空值表示不启用去重。
+    /// </summary>
+    string? DeduplicationKey { get; }
+}

--- a/GalgameManager/Models/BgTasks/KeyMappingTask.cs
+++ b/GalgameManager/Models/BgTasks/KeyMappingTask.cs
@@ -17,14 +17,18 @@ public class KeyMappingTask : BgTaskBase
     public Galgame? Galgame;
     public override bool ProgressOnTrayIcon => false;
     public List<KeyMapping> KeyMappings { get; set; } = new();
+    public bool HasPreLaunchProcessSnapshot { get; set; } // 是否已经在启动游戏前采集安装目录进程快照
+    public List<int> PreExistingProcessIds { get; set; } = []; // 启动前已经存在于安装目录的进程Id
 
-    private Process? _process;
+    private volatile Process? _process;
+    private GameRuntimeProcessRelay? _processRelay;
     private string[] _directoryPrefixes = [];
     private readonly HashSet<int> _trackedProcessIds = [];
     private List<KeyMapping> _runtimeGameMappings = [];
     private bool _runtimeGameMappingOptInEnabled;
     private KeyMappingRuntimeSnapshot _snapshot = KeyMappingRuntimeSnapshot.Empty;
     private KeyMappingRuntimeSnapshot? _pendingSnapshot;
+    private volatile int _confirmedGameplayProcessId;
     private readonly Dictionary<int, KeyMappingOutput> _activeKeyboardMappings = new();
     private readonly Dictionary<int, KeyMappingOutput> _activeMouseMappings = new();
     private readonly HashSet<int> _pressedPhysicalKeyboardKeys = [];
@@ -149,12 +153,30 @@ public class KeyMappingTask : BgTaskBase
     }
 
     public KeyMappingTask(Galgame game, Process process, IEnumerable<KeyMapping> keyMappings)
+        : this(game, process, keyMappings, null, null)
+    {
+    }
+
+    public KeyMappingTask(Galgame game, Process process, IEnumerable<KeyMapping> keyMappings,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay)
         : this()
     {
-        ProcessName = process.ProcessName;
         Galgame = game;
         _process = process;
+        _processRelay = processRelay;
+        HasPreLaunchProcessSnapshot = preExistingProcessIds is not null;
+        PreExistingProcessIds = preExistingProcessIds?.ToList() ?? [];
+        foreach (int processId in PreExistingProcessIds)
+            _trackedProcessIds.Add(processId);
         _trackedProcessIds.Add(GameProcessDetector.SafeGetId(process));
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 短命启动器可能在任务创建前已经退出，仍保留任务以便接力到正式游戏进程。
+        }
         KeyMappings = keyMappings.Select(m => new KeyMapping
         {
             From = new List<int>(m.From),
@@ -171,6 +193,8 @@ public class KeyMappingTask : BgTaskBase
     protected override Task RecoverFromJsonInternal()
     {
         _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
+        HasPreLaunchProcessSnapshot = false;
+        PreExistingProcessIds = [];
         if (_process is not null) _trackedProcessIds.Add(GameProcessDetector.SafeGetId(_process));
         InitDirectoryPrefixes();
         return Task.CompletedTask;
@@ -364,23 +388,51 @@ public class KeyMappingTask : BgTaskBase
     {
         while (_process is not null)
         {
-            try
+            TryFollowConfirmedProcess();
+            Process? tracked = _process;
+            if (tracked is null) break;
+            while (ReferenceEquals(_process, tracked) && GameProcessDetector.IsAlive(tracked))
             {
-                await _process.WaitForExitAsync();
+                TryFollowConfirmedProcess();
+                await Task.Delay(200);
             }
-            catch
-            {
-                // ShellExecute 和快捷方式返回的 Process 可能无法等待，交给目录探测兜底。
-            }
+            if (!ReferenceEquals(_process, tracked)) continue;
 
-            int exitedProcessId = GameProcessDetector.SafeGetId(_process);
+            int exitedProcessId = GameProcessDetector.SafeGetId(tracked);
             if (exitedProcessId > 0) _trackedProcessIds.Add(exitedProcessId);
+            if (!GameSessionExitPolicy.ShouldWaitForReplacement(
+                    _confirmedGameplayProcessId > 0, _confirmedGameplayProcessId, exitedProcessId))
+                break;
             Process? replacement = await WaitForReplacementProcessAsync();
             if (replacement is null) break;
 
-            _process = replacement;
-            ProcessName = replacement.ProcessName;
-            _trackedProcessIds.Add(replacement.Id);
+            AttachProcess(replacement);
+        }
+    }
+
+    private void TryFollowConfirmedProcess()
+    {
+        Process? confirmed = _processRelay?.ConfirmedProcess;
+        if (confirmed is null || !GameProcessDetector.IsAlive(confirmed)) return;
+        int confirmedProcessId = GameProcessDetector.SafeGetId(confirmed);
+        if (confirmedProcessId <= 0) return;
+
+        _confirmedGameplayProcessId = confirmedProcessId;
+        if (_process is not null && GameProcessDetector.SafeGetId(_process) == confirmedProcessId) return;
+        AttachProcess(confirmed);
+    }
+
+    private void AttachProcess(Process process)
+    {
+        _process = process;
+        _trackedProcessIds.Add(GameProcessDetector.SafeGetId(process));
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 进程可能在身份切换期间退出，后续仍由生命周期检查完成清理。
         }
     }
 
@@ -636,7 +688,9 @@ public class KeyMappingTask : BgTaskBase
 
         try
         {
-            if (_process is { HasExited: false } && _process.Id == foregroundProcessId)
+            Process? tracked = _process;
+            if (tracked is not null && GameProcessDetector.IsAlive(tracked) &&
+                GameProcessDetector.SafeGetId(tracked) == foregroundProcessId)
             {
                 matchReason = "跟踪进程一致";
                 return true;

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -20,14 +20,26 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     public DateTime StartTime { get; set; }= DateTime.Now;
     public int CurrentPlayTime { get; set; } //本次游玩时间
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
+    public bool HasPreLaunchProcessSnapshot { get; set; } // 是否已经在启动游戏前采集安装目录进程快照
+    public List<int> PreExistingProcessIds { get; set; } = []; // 启动前已经存在于安装目录的进程Id
+    public bool DelayPlayTimeUntilMainWindow { get; set; } // 等待声明/启动器窗口切换后再开始计时
     public override bool ProgressOnTrayIcon => true;
     public string? DeduplicationKey => Galgame?.Uuid.ToString("D");
 
     public Galgame? Galgame;
-    private Process? _process;
+    private volatile Process? _process;
     private string? _directoryPrefix; // 安装目录前缀，用于退出后探测新出现的游戏进程
     private HashSet<int>? _knownProcessIds; // 开始跟踪时已存在于安装目录的进程，复查时只附着新出现的进程
+    private readonly object _knownProcessIdsLock = new();
     private volatile bool _stopped;
+    private bool _recoveredFromJson;
+    private volatile bool _recordingStarted;
+    private volatile int _confirmedGameplayProcessId;
+    private readonly StableProcessHandoffGate _foregroundProcessHandoffGate = new();
+    private readonly StableGameWindowGate _directWindowGate = new();
+    private GameRuntimeProcessRelay? _processRelay;
+    private GameWindowSnapshot? _initialWindowSnapshot;
+    private GameLaunchWindowTracker? _launchWindowTracker;
 
     private readonly ILocalSettingsService _localSettingsService = App.GetService<ILocalSettingsService>();
     private readonly IGalgameCollectionService _gameService = App.GetService<IGalgameCollectionService>();
@@ -52,26 +64,81 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     /// <param name="process">要跟踪的游戏进程</param>
     /// <param name="installationId">本次游玩使用的安装实例Id</param>
     public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId)
+        : this(game, process, installationId, null, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用启动前进程快照和运行时进程接力创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay)
+        : this(game, process, installationId, preExistingProcessIds, processRelay, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用启动前进程快照、运行时接力和任务创建时的窗口快照创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    /// <param name="initialWindowSnapshot">创建后台任务前捕获到的首个窗口</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay,
+        GameWindowSnapshot? initialWindowSnapshot)
+        : this(game, process, installationId, preExistingProcessIds, processRelay, initialWindowSnapshot, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用完整启动上下文创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    /// <param name="processRelay">向同一启动会话的辅助任务发布正式游戏进程</param>
+    /// <param name="initialWindowSnapshot">创建后台任务前捕获到的首个窗口</param>
+    /// <param name="launchWindowTracker">从启动动作前开始保存窗口变化的追踪器</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds, GameRuntimeProcessRelay? processRelay,
+        GameWindowSnapshot? initialWindowSnapshot, GameLaunchWindowTracker? launchWindowTracker)
     {
         Debug.Assert(game.IsLocalGame);
+        Galgame = game;
+        _process = process;
+        _processRelay = processRelay;
+        _initialWindowSnapshot = initialWindowSnapshot;
+        _launchWindowTracker = launchWindowTracker;
+        InstallationId = installationId;
+        HasPreLaunchProcessSnapshot = preExistingProcessIds is not null;
+        PreExistingProcessIds = preExistingProcessIds?.ToList() ?? [];
         try
         {
-            if (process.HasExited) return;
             ProcessName = process.ProcessName;
         }
         catch
         {
-            // 进程对象可能无效（例如通过ShellExecute启动的快捷方式），仍创建任务，由退出后的目录检查兜底
+            // 进程对象可能无效（例如通过 ShellExecute 启动的快捷方式），仍创建任务，由目录检查兜底。
         }
-        Galgame = game;
-        _process = process;
-        InstallationId = installationId;
+        DelayPlayTimeUntilMainWindow = game.SourceEntries.FirstOrDefault(e => e.EntryId == installationId)
+            ?.LocalConfig?.DelayPlayTimeUntilMainWindow == true;
         InitDirectoryWatch();
     }
 
     protected override Task RecoverFromJsonInternal()
     {
+        _recoveredFromJson = true;
         _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
+        HasPreLaunchProcessSnapshot = false;
         InitDirectoryWatch();
         return Task.CompletedTask;
     }
@@ -81,32 +148,71 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
         string? path = Galgame?.SourceEntries.FirstOrDefault(e => e.EntryId == InstallationId)?.Path;
         if (string.IsNullOrEmpty(path)) return;
         _directoryPrefix = GameProcessDetector.GetDirectoryPrefix(path);
-        _knownProcessIds = GameProcessDetector.GetProcessIdsInDirectory(_directoryPrefix);
+        _knownProcessIds = HasPreLaunchProcessSnapshot
+            ? new HashSet<int>(PreExistingProcessIds)
+            : GameProcessDetector.GetProcessIdsInDirectory(_directoryPrefix);
     }
 
-    protected async override Task RunInternal()
+    protected override async Task RunInternal()
+    {
+        try
+        {
+            await RunCoreAsync();
+        }
+        finally
+        {
+            _launchWindowTracker?.Stop();
+            _processRelay?.Complete();
+        }
+    }
+
+    private async Task RunCoreAsync()
     {
         if(_process is null || Galgame is null) return ;
         ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
         Task t = Task.Run(async () =>
         {
-            // 被跟踪的进程退出后，游戏目录内可能出现真正的游戏进程（启动器场景），尝试重新附着
             while (true)
             {
+                Process? tracked = _process;
+                if (tracked is null) break;
+                int trackedProcessId = GameProcessDetector.SafeGetId(tracked);
+                while (ReferenceEquals(_process, tracked) && GameProcessDetector.IsAlive(tracked))
+                {
+                    if (_confirmedGameplayProcessId <= 0)
+                    {
+                        TryAttachStableForegroundProcess(_foregroundProcessHandoffGate);
+                        TryConfirmDirectGameplayProcess(_process);
+                    }
+                    await Task.Delay(500);
+                }
+
+                if (!ReferenceEquals(_process, tracked)) continue;
+                if (!GameSessionExitPolicy.ShouldWaitForReplacement(
+                        _recordingStarted, _confirmedGameplayProcessId, trackedProcessId))
+                {
+                    App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+                        $"Confirmed gameplay process exited; finishing immediately: gameUuid={Galgame.Uuid:D}, " +
+                        $"installationId={InstallationId:D}, pid={trackedProcessId}");
+                    break;
+                }
+
+                Process? next;
                 try
                 {
-                    await _process.WaitForExitAsync();
+                    next = await WaitForReplacementProcessAsync(trackedProcessId);
                 }
                 catch
                 {
-                    // 进程对象无效（例如通过ShellExecute启动的快捷方式），直接进行目录检查
+                    next = null;
                 }
-                Process? next = await WaitForReplacementProcessAsync(GameProcessDetector.SafeGetId(_process));
+                if (!ReferenceEquals(_process, tracked))
+                {
+                    next?.Dispose();
+                    continue;
+                }
                 if (next is null) break;
-                _process = next;
-                ProcessName = next.ProcessName;
-                _knownProcessIds?.Add(next.Id);
-                ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
+                AttachProcess(next, "previous process exited");
             }
             _stopped = true;
             var windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
@@ -148,15 +254,19 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     private async Task<Process?> WaitForReplacementProcessAsync(int exitedProcessId)
     {
         if (_directoryPrefix is null || _knownProcessIds is null) return null;
-        _knownProcessIds.Add(exitedProcessId);
+        lock (_knownProcessIdsLock)
+            _knownProcessIds.Add(exitedProcessId);
         for (int i = 0; i < 5; i++)
         {
             ChangeProgress(0, 1,
                 "RecordPlayTimeTask_WaitingForProcess".GetLocalized(Galgame!.Name.Value ?? string.Empty,
                     (5 - i).ToString()));
             await Task.Delay(1000);
+            int[] excludedProcessIds;
+            lock (_knownProcessIdsLock)
+                excludedProcessIds = _knownProcessIds.ToArray();
             Process? candidate =
-                GameProcessDetector.FindBestProcessInDirectory(_directoryPrefix, _knownProcessIds);
+                GameProcessDetector.FindBestProcessInDirectory(_directoryPrefix, excludedProcessIds);
             if (candidate is not null) return candidate;
         }
         return null;
@@ -169,6 +279,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             var recordOnlyWhenForeground =
                 await _localSettingsService.ReadSettingAsync<bool>(KeyValues.RecordOnlyWhenForeground);
             _minPlayTimeRecordThreshold = await _localSettingsService.ReadSettingAsync<int>(KeyValues.MinPlayTimeRecordThreshold);
+            if (!await WaitForPlayableWindowAsync()) return;
             try
             {
                 _localSettingsService.OnSettingChanged += OnSettingChanged;
@@ -210,6 +321,170 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 
     public override bool OnSearch(string key) =>
         Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
+
+    private void TryConfirmDirectGameplayProcess(Process? process)
+    {
+        if (!_recordingStarted || process is null || !GameProcessDetector.IsAlive(process)) return;
+        // 启用弹窗等待的安装实例只能由窗口切换门控确认。恢复任务缺少启动前快照，
+        // 此时将稳定存在的游戏窗口作为最安全的确认依据。
+        if (DelayPlayTimeUntilMainWindow && !_recoveredFromJson) return;
+
+        GameWindowSnapshot? snapshot = GameProcessDetector.TryGetPrimaryWindowSnapshot(process);
+        if (!_directWindowGate.Observe(snapshot) || !snapshot.HasValue) return;
+        if (_confirmedGameplayProcessId == snapshot.Value.ProcessId) return;
+
+        _confirmedGameplayProcessId = snapshot.Value.ProcessId;
+        PublishGameplayProcess(process, _confirmedGameplayProcessId);
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Gameplay process confirmed by stable window: gameUuid={Galgame!.Uuid:D}, " +
+            $"installationId={InstallationId:D}, pid={_confirmedGameplayProcessId}");
+    }
+
+    private async Task<bool> WaitForPlayableWindowAsync()
+    {
+        // 恢复任务可能已经附着到正式游戏窗口，但无法还原启动前快照；
+        // 若仍等待窗口切换，PotatoVN 重启后可能永远无法开始计时。
+        if (!DelayPlayTimeUntilMainWindow || _recoveredFromJson)
+        {
+            _recordingStarted = true;
+            return true;
+        }
+
+        bool hasPreLaunchTracker = _launchWindowTracker is not null;
+        GameLaunchWindowTracker tracker = _launchWindowTracker ??= new GameLaunchWindowTracker();
+        if (_initialWindowSnapshot is { } initialSnapshot)
+        {
+            _ = tracker.Observe(initialSnapshot);
+            _initialWindowSnapshot = null;
+        }
+        ChangeProgress(0, 1,
+            "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
+        while (!_stopped)
+        {
+            Process? current = _process;
+            GameWindowSnapshot? snapshot = current is not null && GameProcessDetector.IsAlive(current)
+                ? GameProcessDetector.TryGetPrimaryWindowSnapshot(current)
+                : null;
+            // 启动前追踪器会同时观察安装目录中的替代进程；当前短命进程没有窗口，
+            // 不能用它的空快照清除另一个进程中已经捕获到的正式窗口候选。
+            if (snapshot.HasValue || !hasPreLaunchTracker) _ = tracker.Observe(snapshot);
+            foreach (GameWindowSnapshot observed in tracker.DrainLogSnapshots()) LogWindowObservation(observed);
+
+            GameWindowSnapshot? confirmedSnapshot = tracker.ConfirmedSnapshot;
+            if (confirmedSnapshot.HasValue && TryAttachConfirmedGameplayProcess(confirmedSnapshot.Value))
+            {
+                _recordingStarted = true;
+                _confirmedGameplayProcessId = confirmedSnapshot.Value.ProcessId;
+                Process? confirmedProcess = _process;
+                if (confirmedProcess is not null)
+                    PublishGameplayProcess(confirmedProcess, _confirmedGameplayProcessId);
+                ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
+                App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+                    $"Play-time recording started after window transition: gameUuid={Galgame.Uuid:D}, " +
+                    $"installationId={InstallationId:D}, pid={_confirmedGameplayProcessId}");
+                return true;
+            }
+            await Task.Delay(100);
+        }
+        return false;
+    }
+
+    private bool TryAttachConfirmedGameplayProcess(GameWindowSnapshot confirmedSnapshot)
+    {
+        Process? current = _process;
+        if (current is not null && GameProcessDetector.SafeGetId(current) == confirmedSnapshot.ProcessId)
+            return GameProcessDetector.IsAlive(current);
+
+        Process? confirmedProcess = null;
+        try
+        {
+            confirmedProcess = Process.GetProcessById(confirmedSnapshot.ProcessId);
+            if (!GameProcessDetector.IsAlive(confirmedProcess) ||
+                (_directoryPrefix is not null &&
+                 !GameProcessDetector.IsProcessInDirectory(confirmedProcess, _directoryPrefix)))
+            {
+                confirmedProcess.Dispose();
+                return false;
+            }
+            AttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
+            return true;
+        }
+        catch
+        {
+            confirmedProcess?.Dispose();
+            return false;
+        }
+    }
+
+    private void PublishGameplayProcess(Process process, int processId)
+    {
+        if (processId > 0 && GameProcessDetector.SafeGetId(process) == processId)
+            _processRelay?.Confirm(process);
+    }
+
+    private void TryAttachStableForegroundProcess(StableProcessHandoffGate handoffGate)
+    {
+        if (_directoryPrefix is null) return;
+        Process? foreground = GameProcessDetector.TryGetForegroundProcessInDirectory(_directoryPrefix);
+        if (foreground is null)
+        {
+            int currentProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+            _ = handoffGate.Observe(currentProcessId, null);
+            return;
+        }
+
+        int trackedProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+        int foregroundProcessId = GameProcessDetector.SafeGetId(foreground);
+        bool existedBeforeLaunch;
+        lock (_knownProcessIdsLock)
+            existedBeforeLaunch = _knownProcessIds?.Contains(foregroundProcessId) == true;
+        if (existedBeforeLaunch)
+        {
+            _ = handoffGate.Observe(trackedProcessId, null);
+            foreground.Dispose();
+            return;
+        }
+        if (!handoffGate.Observe(trackedProcessId, foregroundProcessId))
+        {
+            foreground.Dispose();
+            return;
+        }
+
+        AttachProcess(foreground, "stable foreground process in installation directory");
+    }
+
+    private void AttachProcess(Process process, string reason)
+    {
+        int previousProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
+        _process = process;
+        _confirmedGameplayProcessId = 0;
+        _directWindowGate.Reset();
+        try
+        {
+            ProcessName = process.ProcessName;
+        }
+        catch
+        {
+            // 进程可能在接替期间退出，后续生命周期检查会继续处理。
+        }
+        lock (_knownProcessIdsLock)
+            _knownProcessIds?.Add(GameProcessDetector.SafeGetId(process));
+        ChangeProgress(0, 1, _recordingStarted
+            ? "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame!.Name.Value!)
+            : "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Play-time process attached: gameUuid={Galgame.Uuid:D}, installationId={InstallationId:D}, " +
+            $"previousPid={previousProcessId}, pid={GameProcessDetector.SafeGetId(process)}, " +
+            $"process={ProcessName}, reason={reason}");
+    }
+
+    private void LogWindowObservation(GameWindowSnapshot snapshot)
+    {
+        App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Play-time window observed: gameUuid={Galgame!.Uuid:D}, installationId={InstallationId:D}, " +
+            $"pid={snapshot.ProcessId}, hwnd=0x{snapshot.WindowHandle:X}, class={snapshot.ClassName}, " +
+            $"size={snapshot.Width}x{snapshot.Height}, title={snapshot.Title}");
+    }
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -19,6 +19,10 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     public string ProcessName { get; set; } = string.Empty;
     public DateTime StartTime { get; set; }= DateTime.Now;
     public int CurrentPlayTime { get; set; } //本次游玩时间
+    public long CurrentPlayTimeSeconds { get; set; } // 本次实际累计秒数
+    public bool? PrecisePlayTimeMode { get; set; } // 本次启动锁定的计时模式，恢复任务时保持不变
+    public Guid? ActiveSessionId { get; set; } // 异常退出/托盘恢复时继续同一原生时段
+    public Guid? ActiveMinuteSessionId { get; set; } // 异常退出/托盘恢复时继续同一条分钟级启动分段
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
     public bool HasPreLaunchProcessSnapshot { get; set; } // 是否已经在启动游戏前采集安装目录进程快照
     public List<int> PreExistingProcessIds { get; set; } = []; // 启动前已经存在于安装目录的进程Id
@@ -35,8 +39,9 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     private bool _recoveredFromJson;
     private volatile bool _recordingStarted;
     private volatile int _confirmedGameplayProcessId;
-    private readonly StableProcessHandoffGate _foregroundProcessHandoffGate = new();
     private readonly StableGameWindowGate _directWindowGate = new();
+    private readonly StableProcessHandoffGate _foregroundProcessHandoffGate = new();
+    private bool _recordingStartedMessageSent;
     private GameRuntimeProcessRelay? _processRelay;
     private GameWindowSnapshot? _initialWindowSnapshot;
     private GameLaunchWindowTracker? _launchWindowTracker;
@@ -64,7 +69,20 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     /// <param name="process">要跟踪的游戏进程</param>
     /// <param name="installationId">本次游玩使用的安装实例Id</param>
     public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId)
-        : this(game, process, installationId, null, null)
+        : this(game, process, installationId, null)
+    {
+    }
+
+    /// <summary>
+    /// 使用启动前进程快照创建游玩时间记录任务。
+    /// </summary>
+    /// <param name="game">目标逻辑游戏</param>
+    /// <param name="process">启动操作返回的初始进程</param>
+    /// <param name="installationId">本次游玩使用的安装实例Id</param>
+    /// <param name="preExistingProcessIds">启动前已经存在于安装目录的进程Id</param>
+    public RecordPlayTimeTask(Galgame game, Process process, Guid? installationId,
+        IReadOnlyCollection<int>? preExistingProcessIds)
+        : this(game, process, installationId, preExistingProcessIds, null)
     {
     }
 
@@ -127,7 +145,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
         }
         catch
         {
-            // 进程对象可能无效（例如通过 ShellExecute 启动的快捷方式），仍创建任务，由目录检查兜底。
+            // 进程对象可能无效（例如通过ShellExecute启动的快捷方式），仍创建任务，由退出后的目录检查兜底
         }
         DelayPlayTimeUntilMainWindow = game.SourceEntries.FirstOrDefault(e => e.EntryId == installationId)
             ?.LocalConfig?.DelayPlayTimeUntilMainWindow == true;
@@ -137,10 +155,53 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     protected override Task RecoverFromJsonInternal()
     {
         _recoveredFromJson = true;
-        _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
         HasPreLaunchProcessSnapshot = false;
         InitDirectoryWatch();
+        _process = FindRecoveryProcess();
         return Task.CompletedTask;
+    }
+
+    private Process? FindRecoveryProcess()
+    {
+        Process? directoryProcess = _directoryPrefix is null
+            ? null
+            : GameProcessDetector.FindBestProcessInDirectory(
+                _directoryPrefix,
+                requiredProcessName: ProcessName);
+        if (directoryProcess is not null) return directoryProcess;
+
+        Process[] candidates = string.IsNullOrWhiteSpace(ProcessName)
+            ? []
+            : Process.GetProcessesByName(ProcessName);
+        Process? result = null;
+        foreach (Process candidate in candidates)
+        {
+            if (result is null || IsBetterRecoveryCandidate(candidate, result))
+            {
+                result?.Dispose();
+                result = candidate;
+            }
+            else
+            {
+                candidate.Dispose();
+            }
+        }
+        return result;
+
+        static bool IsBetterRecoveryCandidate(Process candidate, Process current)
+        {
+            bool candidateHasWindow = GameProcessDetector.HasWindow(candidate);
+            bool currentHasWindow = GameProcessDetector.HasWindow(current);
+            if (candidateHasWindow != currentHasWindow) return candidateHasWindow;
+            try
+            {
+                return candidate.StartTime > current.StartTime;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 
     private void InitDirectoryWatch()
@@ -168,9 +229,19 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 
     private async Task RunCoreAsync()
     {
-        if(_process is null || Galgame is null) return ;
+        if (Galgame is null) return;
+        if (_process is null)
+        {
+            if (_recoveredFromJson) await FinalizeOrphanedRecoveredSessionsAsync();
+            return;
+        }
+        PrecisePlayTimeMode = PlayTimeRecordingModeHelper.ResolvePreciseMode(
+            PrecisePlayTimeMode,
+            ActiveSessionId.HasValue,
+            await _localSettingsService.ReadSettingAsync<bool>(KeyValues.PrecisePlayTime));
         ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
-        Task t = Task.Run(async () =>
+
+        Task processMonitor = Task.Run(async () =>
         {
             while (true)
             {
@@ -180,16 +251,19 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                 while (ReferenceEquals(_process, tracked) && GameProcessDetector.IsAlive(tracked))
                 {
                     if (_confirmedGameplayProcessId <= 0)
-                    {
                         TryAttachStableForegroundProcess(_foregroundProcessHandoffGate);
-                        TryConfirmDirectGameplayProcess(_process);
-                    }
                     await Task.Delay(500);
                 }
 
+                // 预备计时可能已经主动接替到一个仍在运行的前台游戏进程。
                 if (!ReferenceEquals(_process, tracked)) continue;
+
+                // 已确认进入正式游戏的进程退出后应立即结束（#709）；仍处于启动/弹窗/接力阶段时
+                // 才保留5秒目录扫描，兼容汉化启动器拉起不同exe的场景。
                 if (!GameSessionExitPolicy.ShouldWaitForReplacement(
-                        _recordingStarted, _confirmedGameplayProcessId, trackedProcessId))
+                        _recordingStarted,
+                        _confirmedGameplayProcessId,
+                        trackedProcessId))
                 {
                     App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
                         $"Confirmed gameplay process exited; finishing immediately: gameUuid={Galgame.Uuid:D}, " +
@@ -206,6 +280,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                 {
                     next = null;
                 }
+
                 if (!ReferenceEquals(_process, tracked))
                 {
                     next?.Dispose();
@@ -215,36 +290,74 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                 AttachProcess(next, "previous process exited");
             }
             _stopped = true;
-            var windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
-            await UiThreadInvokeHelper.InvokeAsync(() =>
-            {
-                _gameService.SaveGalgameAsync(Galgame);
-                GalgamePageParameter parma = new()
-                {
-                    Galgame = Galgame,
-                    SelectProgress = DateTime.Now - StartTime < TimeSpan.FromSeconds(ManuallySelectProcessSec)
-                                     && Galgame.SourceEntries.FirstOrDefault(e => e.EntryId == InstallationId)
-                                         ?.LocalConfig?.ProcessName is null
-                };
-                if (windowMode == WindowMode.SystemTray)
-                    App.GetService<INavigationService>().NavigateTo(typeof(GalgameViewModel).FullName!, parma);
-                App.SetWindowMode(WindowMode.Normal);
-                ChangeProgress(1, 1,
-                    "RecordPlayTimeTask_Done".GetLocalized(Galgame.Name.Value ?? string.Empty,
-                        TimeToDisplayTimeConverter.Convert(CurrentPlayTime)));
-                // 手动通知LastPlayTime属性已更改
-                Galgame.RaisePropertyChanged(nameof(Galgame.LastPlayTime));
-                if (CurrentPlayTime >= _minPlayTimeRecordThreshold) Galgame!.PlayCount++;
-                App.GetService<IMessenger>().Send(new GalgameStoppedMessage(Galgame));
-            });
-            await App.GetService<IGalgameCollectionService>().SaveGalgameAsync(Galgame);
-            if(await App.GetService<ILocalSettingsService>().ReadSettingAsync<bool>(KeyValues.SyncGames))
-                App.GetService<IPvnService>().Upload(Galgame, PvnUploadProperties.PlayTime);
         });
 
-        _ = RecordPlayTimeAsync();
+        Task recording = RecordPlayTimeAsync();
+        await processMonitor;
+        await recording;
 
-        await t;
+        WindowMode windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
+        bool precisePlayTime = PrecisePlayTimeMode == true;
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            GalgamePageParameter parma = new()
+            {
+                Galgame = Galgame,
+                SelectProgress = DateTime.Now - StartTime < TimeSpan.FromSeconds(ManuallySelectProcessSec)
+                                 && Galgame.SourceEntries.FirstOrDefault(e => e.EntryId == InstallationId)
+                                     ?.LocalConfig?.ProcessName is null
+            };
+            if (windowMode == WindowMode.SystemTray)
+                App.GetService<INavigationService>().NavigateTo(typeof(GalgameViewModel).FullName!, parma);
+            App.SetWindowMode(WindowMode.Normal);
+            ChangeProgress(1, 1,
+                "RecordPlayTimeTask_Done".GetLocalized(Galgame.Name.Value ?? string.Empty,
+                    precisePlayTime
+                        ? TimeToDisplayTimeConverter.ConvertSeconds(CurrentPlayTimeSeconds)
+                        : TimeToDisplayTimeConverter.Convert(CurrentPlayTime)));
+            Galgame.RaisePropertyChanged(nameof(Galgame.LastPlayTime));
+            bool reachesPlayCountThreshold = precisePlayTime
+                ? CurrentPlayTimeSeconds > 0 &&
+                  CurrentPlayTimeSeconds >= _minPlayTimeRecordThreshold * 60L
+                : CurrentPlayTime >= _minPlayTimeRecordThreshold;
+            if (reachesPlayCountThreshold) Galgame.PlayCount++;
+            App.GetService<IMessenger>().Send(new GalgameStoppedMessage(Galgame));
+        });
+        await _gameService.SaveGalgameAsync(Galgame);
+        if (await _localSettingsService.ReadSettingAsync<bool>(KeyValues.SyncGames))
+            App.GetService<IPvnService>().Upload(Galgame, PvnUploadProperties.PlayTime);
+    }
+
+    /// <summary>
+    /// 恢复时若原进程已经退出，使用最后一次持久化的边界关闭开放记录，
+    /// 避免详情页永久显示“正在记录”。这里不会把应用离线后的时间补入汇总。
+    /// </summary>
+    private async Task FinalizeOrphanedRecoveredSessionsAsync()
+    {
+        bool changed = false;
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            if (ActiveSessionId is { } preciseSessionId)
+            {
+                changed |= PlayTimeSessionHelper.CloseOpenSession(Galgame!, preciseSessionId);
+                ActiveSessionId = null;
+            }
+
+            if (ActiveMinuteSessionId is { } minuteSessionId)
+            {
+                PlayTimeSession? minuteSession = Galgame!.PlayTimeSessions.FirstOrDefault(session =>
+                    session.Id == minuteSessionId && session.Kind == PlayTimeSessionKind.MinuteSampled);
+                changed |= PlayTimeSessionHelper.CloseOpenSession(Galgame, minuteSessionId);
+                ActiveMinuteSessionId = null;
+                if (minuteSession is not null && !PlayTimeSessionHelper.HasMinuteSamples(minuteSession))
+                {
+                    Galgame.PlayTimeSessions.Remove(minuteSession);
+                    PlayTimeSessionHelper.RefreshDerivedState(Galgame);
+                    changed = true;
+                }
+            }
+        });
+        if (changed) await _gameService.SaveGalgameAsync(Galgame!);
     }
 
     /// <summary>
@@ -276,67 +389,259 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     {
         return Task.Run(async () =>
         {
-            var recordOnlyWhenForeground =
+            bool recordOnlyWhenForeground =
                 await _localSettingsService.ReadSettingAsync<bool>(KeyValues.RecordOnlyWhenForeground);
-            _minPlayTimeRecordThreshold = await _localSettingsService.ReadSettingAsync<int>(KeyValues.MinPlayTimeRecordThreshold);
+            _minPlayTimeRecordThreshold =
+                await _localSettingsService.ReadSettingAsync<int>(KeyValues.MinPlayTimeRecordThreshold);
             if (!await WaitForPlayableWindowAsync()) return;
+            SendRecordingStartedMessage();
+
+            if (PrecisePlayTimeMode != true)
+            {
+                await RecordLegacyPlayTimeAsync(recordOnlyWhenForeground);
+                return;
+            }
+
+            PlayTimeSession? launchSession = ActiveSessionId is { } activeId
+                ? Galgame!.PlayTimeSessions.FirstOrDefault(session => session.Id == activeId && session.IsOpen)
+                : null;
+            if (launchSession is null)
+                launchSession = await BeginSessionAsync(DateTime.Now);
+            else
+                await UiThreadInvokeHelper.InvokeAsync(() =>
+                    PlayTimeSessionHelper.EnsureExplicitActivityIntervals(launchSession));
+            PlayTimeActivityInterval? activeInterval = null;
+            DateTime lastSaveAt = DateTime.Now;
+
             try
             {
                 _localSettingsService.OnSettingChanged += OnSettingChanged;
-
                 while (!_stopped)
                 {
-                    Thread.Sleep(1000 * 60);
+                    await Task.Delay(1000);
+                    DateTime now = DateTime.Now;
                     Process? current = _process;
-                    if (_stopped || current is null || !GameProcessDetector.IsAlive(current) ||
-                        (recordOnlyWhenForeground && (current.IsMainWindowMinimized() || !current.IsMainWindowActive())))
-                        continue;
-                    UiThreadInvokeHelper.Invoke(() =>
+                    TryConfirmDirectGameplayProcess(current);
+                    bool eligible = !_stopped && current is not null && GameProcessDetector.IsAlive(current) &&
+                                    (!recordOnlyWhenForeground ||
+                                     (!current.IsMainWindowMinimized() && current.IsMainWindowActive()));
+
+                    if (!eligible)
                     {
-                        Galgame!.TotalPlayTime++;
-                        CurrentPlayTime++;
-                        _gameService.SaveGalgameAsync(Galgame);
+                        activeInterval = null;
+                        await UiThreadInvokeHelper.InvokeAsync(() => launchSession.EndedAt = now);
+                        continue;
+                    }
+
+                    if (activeInterval is null)
+                    {
+                        activeInterval = await BeginActivityIntervalAsync(launchSession, now);
+                        lastSaveAt = now;
+                        continue;
+                    }
+
+                    long sampleSeconds = 0;
+                    await UiThreadInvokeHelper.InvokeAsync(() =>
+                    {
+                        sampleSeconds = PlayTimeSessionHelper.ExtendActivityInterval(
+                            Galgame!, launchSession, activeInterval, now);
+                        CurrentPlayTimeSeconds = CurrentPlayTimeSeconds > long.MaxValue - sampleSeconds
+                            ? long.MaxValue
+                            : CurrentPlayTimeSeconds + sampleSeconds;
+                        CurrentPlayTime = checked((int)Math.Min(int.MaxValue, CurrentPlayTimeSeconds / 60));
                     });
-                    var now = DateTime.Now.ToStringDefault();
-                    if (!Galgame!.PlayedTime.TryAdd(now, 1))
-                        Galgame.PlayedTime[now]++;
+                    if (sampleSeconds <= 0) continue;
+
+                    if (now - lastSaveAt >= TimeSpan.FromSeconds(15))
+                    {
+                        await _gameService.SaveGalgameAsync(Galgame!);
+                        lastSaveAt = now;
+                    }
                 }
             }
             finally
             {
                 _localSettingsService.OnSettingChanged -= OnSettingChanged;
+                await CloseLaunchSessionAsync(launchSession, activeInterval is not null);
             }
-
-            return;
 
             void OnSettingChanged(string key, object? value)
             {
-                if(key == KeyValues.RecordOnlyWhenForeground && value is bool b)
+                if (key == KeyValues.RecordOnlyWhenForeground && value is bool b)
                     recordOnlyWhenForeground = b;
-                if(key == KeyValues.MinPlayTimeRecordThreshold && value is int i)
+                if (key == KeyValues.MinPlayTimeRecordThreshold && value is int i)
                     _minPlayTimeRecordThreshold = i;
             }
         });
     }
 
-    public override bool OnSearch(string key) =>
-        Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
+    private async Task RecordLegacyPlayTimeAsync(bool recordOnlyWhenForeground)
+    {
+        DateTime nextSampleAt = DateTime.Now.AddMinutes(1);
+        PlayTimeSession? launchSession = ActiveMinuteSessionId is { } activeId
+            ? Galgame!.PlayTimeSessions.FirstOrDefault(session =>
+                session.Id == activeId &&
+                session.IsOpen &&
+                session.Kind == PlayTimeSessionKind.MinuteSampled)
+            : null;
+        if (launchSession is null)
+            launchSession = await BeginMinuteSessionAsync(DateTime.Now);
+        try
+        {
+            _localSettingsService.OnSettingChanged += OnSettingChanged;
+            while (!_stopped)
+            {
+                await Task.Delay(1000);
+                DateTime now = DateTime.Now;
+                Process? current = _process;
+                TryConfirmDirectGameplayProcess(current);
+                if (now < nextSampleAt) continue;
+
+                // 与旧版一致，每次唤醒只采样一次；系统休眠或线程延迟不会追补中间分钟。
+                nextSampleAt = now.AddMinutes(1);
+                bool eligible = !_stopped && current is not null && GameProcessDetector.IsAlive(current) &&
+                                (!recordOnlyWhenForeground ||
+                                 (!current.IsMainWindowMinimized() && current.IsMainWindowActive()));
+                if (!eligible) continue;
+
+                await UiThreadInvokeHelper.InvokeAsync(() =>
+                {
+                    PlayTimeSessionHelper.AddLegacyMinuteSample(Galgame!, now, launchSession);
+                    if (CurrentPlayTime < int.MaxValue) CurrentPlayTime++;
+                    CurrentPlayTimeSeconds = CurrentPlayTimeSeconds > long.MaxValue - 60
+                        ? long.MaxValue
+                        : CurrentPlayTimeSeconds + 60;
+                });
+                await _gameService.SaveGalgameAsync(Galgame!);
+            }
+        }
+        finally
+        {
+            _localSettingsService.OnSettingChanged -= OnSettingChanged;
+            await CloseMinuteSessionAsync(launchSession);
+        }
+
+        void OnSettingChanged(string key, object? value)
+        {
+            if (key == KeyValues.RecordOnlyWhenForeground && value is bool b)
+                recordOnlyWhenForeground = b;
+            if (key == KeyValues.MinPlayTimeRecordThreshold && value is int i)
+                _minPlayTimeRecordThreshold = i;
+        }
+    }
+
+    private async Task<PlayTimeSession> BeginMinuteSessionAsync(DateTime startedAt)
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = startedAt,
+            EndedAt = startedAt,
+            IsOpen = true,
+            InstallationId = InstallationId,
+            Kind = PlayTimeSessionKind.MinuteSampled,
+            CountsTowardPlayTime = false,
+            SampledMinutesByDay = [],
+            ActivityIntervals = [],
+        };
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            Galgame!.PlayTimeSessions.Add(session);
+            ActiveMinuteSessionId = session.Id;
+        });
+        await _gameService.SaveGalgameAsync(Galgame!);
+        return session;
+    }
+
+    private async Task CloseMinuteSessionAsync(PlayTimeSession session)
+    {
+        DateTime endedAt = DateTime.Now;
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            session.EndedAt = endedAt < session.StartedAt ? session.StartedAt : endedAt;
+            session.IsOpen = false;
+            ActiveMinuteSessionId = null;
+            if (!PlayTimeSessionHelper.HasMinuteSamples(session))
+                Galgame!.PlayTimeSessions.RemoveAll(item => item.Id == session.Id);
+            PlayTimeSessionHelper.RefreshDerivedState(Galgame!);
+        });
+        await _gameService.SaveGalgameAsync(Galgame!);
+    }
+
+    private async Task<PlayTimeSession> BeginSessionAsync(DateTime startedAt)
+    {
+        PlayTimeSession session = new()
+        {
+            StartedAt = startedAt,
+            EndedAt = startedAt,
+            IsOpen = true,
+            InstallationId = InstallationId,
+            Kind = PlayTimeSessionKind.Native,
+            CountsTowardPlayTime = true,
+            ActivityIntervals = [],
+        };
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            Galgame!.PlayTimeSessions.Add(session);
+            ActiveSessionId = session.Id;
+        });
+        await _gameService.SaveGalgameAsync(Galgame!);
+        return session;
+    }
+
+    private async Task<PlayTimeActivityInterval> BeginActivityIntervalAsync(
+        PlayTimeSession session, DateTime startedAt)
+    {
+        PlayTimeActivityInterval? interval = null;
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+            interval = PlayTimeSessionHelper.BeginActivityInterval(session, startedAt));
+        await _gameService.SaveGalgameAsync(Galgame!);
+        return interval!;
+    }
+
+    private async Task CloseLaunchSessionAsync(PlayTimeSession session, bool extendActiveInterval)
+    {
+        DateTime endedAt = DateTime.Now;
+        await UiThreadInvokeHelper.InvokeAsync(() =>
+        {
+            PlayTimeActivityInterval? interval = session.ActivityIntervals?.LastOrDefault();
+            if (extendActiveInterval && interval is not null)
+            {
+                long addedSeconds = PlayTimeSessionHelper.ExtendActivityInterval(
+                    Galgame!, session, interval, endedAt);
+                CurrentPlayTimeSeconds = CurrentPlayTimeSeconds > long.MaxValue - addedSeconds
+                    ? long.MaxValue
+                    : CurrentPlayTimeSeconds + addedSeconds;
+                CurrentPlayTime = checked((int)Math.Min(int.MaxValue, CurrentPlayTimeSeconds / 60));
+            }
+            session.EndedAt = endedAt < session.StartedAt ? session.StartedAt : endedAt;
+            session.IsOpen = false;
+            ActiveSessionId = null;
+            PlayTimeSessionHelper.RefreshDerivedState(Galgame!);
+        });
+        await _gameService.SaveGalgameAsync(Galgame!);
+    }
+
+    private void SendRecordingStartedMessage()
+    {
+        if (_recordingStartedMessageSent || Galgame is null) return;
+        _recordingStartedMessageSent = true;
+        App.GetService<IMessenger>().Send(new GalgamePlayTimeRecordingStartedMessage(Galgame));
+    }
 
     private void TryConfirmDirectGameplayProcess(Process? process)
     {
         if (!_recordingStarted || process is null || !GameProcessDetector.IsAlive(process)) return;
-        // 启用弹窗等待的安装实例只能由窗口切换门控确认。恢复任务缺少启动前快照，
+        // 启用弹窗等待的安装实例只能由下方切换门控确认。恢复任务缺少启动前快照，
         // 此时将稳定存在的游戏窗口作为最安全的确认依据。
         if (DelayPlayTimeUntilMainWindow && !_recoveredFromJson) return;
 
         GameWindowSnapshot? snapshot = GameProcessDetector.TryGetPrimaryWindowSnapshot(process);
         if (!_directWindowGate.Observe(snapshot) || !snapshot.HasValue) return;
         if (_confirmedGameplayProcessId == snapshot.Value.ProcessId) return;
-
         _confirmedGameplayProcessId = snapshot.Value.ProcessId;
-        PublishGameplayProcess(process, _confirmedGameplayProcessId);
+        SendGameplayProcessConfirmedMessage(_confirmedGameplayProcessId);
         App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
-            $"Gameplay process confirmed by stable window: gameUuid={Galgame!.Uuid:D}, " +
+            $"Direct gameplay process confirmed by stable window: gameUuid={Galgame!.Uuid:D}, " +
             $"installationId={InstallationId:D}, pid={_confirmedGameplayProcessId}");
     }
 
@@ -375,9 +680,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             {
                 _recordingStarted = true;
                 _confirmedGameplayProcessId = confirmedSnapshot.Value.ProcessId;
-                Process? confirmedProcess = _process;
-                if (confirmedProcess is not null)
-                    PublishGameplayProcess(confirmedProcess, _confirmedGameplayProcessId);
+                SendGameplayProcessConfirmedMessage(_confirmedGameplayProcessId);
                 ChangeProgress(0, 1, "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame.Name.Value!));
                 App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
                     $"Play-time recording started after window transition: gameUuid={Galgame.Uuid:D}, " +
@@ -416,10 +719,12 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
         }
     }
 
-    private void PublishGameplayProcess(Process process, int processId)
+    private void SendGameplayProcessConfirmedMessage(int processId)
     {
-        if (processId > 0 && GameProcessDetector.SafeGetId(process) == processId)
-            _processRelay?.Confirm(process);
+        if (Galgame is null || processId <= 0) return;
+        Process? current = _process;
+        if (current is not null && GameProcessDetector.SafeGetId(current) == processId)
+            _processRelay?.Confirm(current);
     }
 
     private void TryAttachStableForegroundProcess(StableProcessHandoffGate handoffGate)
@@ -457,25 +762,17 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
     {
         int previousProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
         _process = process;
+        ProcessName = process.ProcessName;
         _confirmedGameplayProcessId = 0;
         _directWindowGate.Reset();
-        try
-        {
-            ProcessName = process.ProcessName;
-        }
-        catch
-        {
-            // 进程可能在接替期间退出，后续生命周期检查会继续处理。
-        }
         lock (_knownProcessIdsLock)
-            _knownProcessIds?.Add(GameProcessDetector.SafeGetId(process));
+            _knownProcessIds?.Add(process.Id);
         ChangeProgress(0, 1, _recordingStarted
             ? "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame!.Name.Value!)
             : "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
         App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
             $"Play-time process attached: gameUuid={Galgame.Uuid:D}, installationId={InstallationId:D}, " +
-            $"previousPid={previousProcessId}, pid={GameProcessDetector.SafeGetId(process)}, " +
-            $"process={ProcessName}, reason={reason}");
+            $"previousPid={previousProcessId}, pid={process.Id}, process={ProcessName}, reason={reason}");
     }
 
     private void LogWindowObservation(GameWindowSnapshot snapshot)
@@ -485,6 +782,9 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             $"pid={snapshot.ProcessId}, hwnd=0x{snapshot.WindowHandle:X}, class={snapshot.ClassName}, " +
             $"size={snapshot.Width}x{snapshot.Height}, title={snapshot.Title}");
     }
+
+    public override bool OnSearch(string key) =>
+        Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -12,7 +12,7 @@ using GalgameManager.WinApp.Base.Models.Msgs;
 
 namespace GalgameManager.Models.BgTasks;
 
-public class RecordPlayTimeTask : BgTaskBase
+public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
 {
     private const int ManuallySelectProcessSec = 15; //认定为需要手动选择游戏进程的时间阈值
 
@@ -21,6 +21,7 @@ public class RecordPlayTimeTask : BgTaskBase
     public int CurrentPlayTime { get; set; } //本次游玩时间
     public Guid? InstallationId { get; set; } // 本次游玩使用的安装实例Id
     public override bool ProgressOnTrayIcon => true;
+    public string? DeduplicationKey => Galgame?.Uuid.ToString("D");
 
     public Galgame? Galgame;
     private Process? _process;
@@ -206,6 +207,9 @@ public class RecordPlayTimeTask : BgTaskBase
             }
         });
     }
+
+    public override bool OnSearch(string key) =>
+        Galgame is not null && string.Equals(Galgame.Uuid.ToString("D"), key, StringComparison.OrdinalIgnoreCase);
 
     public override string Title { get; } = "RecordPlayTimeTask_Title".GetLocalized();
 }

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -548,7 +548,20 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             Galgame!.PlayTimeSessions.Add(session);
             ActiveMinuteSessionId = session.Id;
         });
-        await _gameService.SaveGalgameAsync(Galgame!);
+        try
+        {
+            await _gameService.SaveGalgameAsync(Galgame!);
+        }
+        catch
+        {
+            await UiThreadInvokeHelper.InvokeAsync(() =>
+            {
+                Galgame!.PlayTimeSessions.RemoveAll(item => item.Id == session.Id);
+                if (ActiveMinuteSessionId == session.Id) ActiveMinuteSessionId = null;
+                PlayTimeSessionHelper.RefreshDerivedState(Galgame);
+            });
+            throw;
+        }
         return session;
     }
 
@@ -584,7 +597,20 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             Galgame!.PlayTimeSessions.Add(session);
             ActiveSessionId = session.Id;
         });
-        await _gameService.SaveGalgameAsync(Galgame!);
+        try
+        {
+            await _gameService.SaveGalgameAsync(Galgame!);
+        }
+        catch
+        {
+            await UiThreadInvokeHelper.InvokeAsync(() =>
+            {
+                Galgame!.PlayTimeSessions.RemoveAll(item => item.Id == session.Id);
+                if (ActiveSessionId == session.Id) ActiveSessionId = null;
+                PlayTimeSessionHelper.RefreshDerivedState(Galgame);
+            });
+            throw;
+        }
         return session;
     }
 

--- a/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
+++ b/GalgameManager/Models/BgTasks/RecordPlayTimeTask.cs
@@ -212,7 +212,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                     continue;
                 }
                 if (next is null) break;
-                AttachProcess(next, "previous process exited");
+                if (!TryAttachProcess(next, "previous process exited")) continue;
             }
             _stopped = true;
             var windowMode = await _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode);
@@ -406,8 +406,7 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
                 confirmedProcess.Dispose();
                 return false;
             }
-            AttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
-            return true;
+            return TryAttachProcess(confirmedProcess, "gameplay window confirmed from launch history");
         }
         catch
         {
@@ -450,32 +449,47 @@ public class RecordPlayTimeTask : BgTaskBase, IDeduplicatedBgTask
             return;
         }
 
-        AttachProcess(foreground, "stable foreground process in installation directory");
+        _ = TryAttachProcess(foreground, "stable foreground process in installation directory");
     }
 
-    private void AttachProcess(Process process, string reason)
+    private bool TryAttachProcess(Process process, string reason)
     {
+        int processId = GameProcessDetector.SafeGetId(process);
+        string processName;
+        try
+        {
+            processName = process.ProcessName;
+        }
+        catch
+        {
+            lock (_knownProcessIdsLock)
+                if (processId > 0) _knownProcessIds?.Add(processId);
+            process.Dispose();
+            return false;
+        }
+        if (processId <= 0 || !GameProcessDetector.IsAlive(process))
+        {
+            lock (_knownProcessIdsLock)
+                if (processId > 0) _knownProcessIds?.Add(processId);
+            process.Dispose();
+            return false;
+        }
+
         int previousProcessId = _process is null ? -1 : GameProcessDetector.SafeGetId(_process);
         _process = process;
         _confirmedGameplayProcessId = 0;
         _directWindowGate.Reset();
-        try
-        {
-            ProcessName = process.ProcessName;
-        }
-        catch
-        {
-            // 进程可能在接替期间退出，后续生命周期检查会继续处理。
-        }
+        ProcessName = processName;
         lock (_knownProcessIdsLock)
-            _knownProcessIds?.Add(GameProcessDetector.SafeGetId(process));
+            _knownProcessIds?.Add(processId);
         ChangeProgress(0, 1, _recordingStarted
             ? "RecordPlayTimeTask_ProgressMsg".GetLocalized(Galgame!.Name.Value!)
             : "RecordPlayTimeTask_WaitingForMainWindow".GetLocalized(Galgame!.Name.Value ?? string.Empty));
         App.GetService<IInfoService>().Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
             $"Play-time process attached: gameUuid={Galgame.Uuid:D}, installationId={InstallationId:D}, " +
-            $"previousPid={previousProcessId}, pid={GameProcessDetector.SafeGetId(process)}, " +
+            $"previousPid={previousProcessId}, pid={processId}, " +
             $"process={ProcessName}, reason={reason}");
+        return true;
     }
 
     private void LogWindowObservation(GameWindowSnapshot snapshot)

--- a/GalgameManager/Services/BgTaskService.cs
+++ b/GalgameManager/Services/BgTaskService.cs
@@ -132,9 +132,29 @@ public class BgTaskService : IBgTaskService
     {
         try
         {
+            string? rejectedDuplicateKey = null;
             lock (_bgTasksLock)
             {
-                _bgTasks.Add(bgTask);
+                if (bgTask is IDeduplicatedBgTask { DeduplicationKey: { Length: > 0 } key } &&
+                    _bgTasks.Any(existing => existing.GetType() == bgTask.GetType() &&
+                                             existing is IDeduplicatedBgTask deduplicated &&
+                                             string.Equals(deduplicated.DeduplicationKey, key,
+                                                 StringComparison.Ordinal)))
+                {
+                    rejectedDuplicateKey = key;
+                }
+                else
+                {
+                    _bgTasks.Add(bgTask);
+                }
+            }
+
+            if (rejectedDuplicateKey is not null)
+            {
+                _infoService.DeveloperEvent(
+                    msg: $"Ignored duplicate background task: type={bgTask.GetType().Name}, " +
+                         $"key={rejectedDuplicateKey}");
+                return Task.CompletedTask;
             }
 
             if (bgTask.ProgressOnTrayIcon)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -94,11 +94,17 @@ public sealed class GameLaunchService(
             if (string.IsNullOrEmpty(config.ExePath)) return;
         }
 
+        GameRuntimeProcessRelay processRelay = new();
         Process? process = null;
+        IReadOnlyCollection<int> preExistingProcessIds = [];
+        GameLaunchWindowTracker? launchWindowTracker = null;
         try
         {
             if (isSteam)
             {
+                preExistingProcessIds = GameProcessDetector.GetProcessIdsInDirectory(
+                    GameProcessDetector.GetDirectoryPrefix(installation.Path));
+                launchWindowTracker = StartLaunchWindowTracker(config, installation.Path, preExistingProcessIds);
                 Uri steamUri = new($"steam://run/{game.Ids[(int)RssType.Steam]}");
                 infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
                     msg: "GalgamePage_Play_StartingSteam".GetLocalized());
@@ -118,11 +124,11 @@ public sealed class GameLaunchService(
                     {
                         if (!await DisplaySteamMessageAsync()) return;
                         if (!await SelectProcessAsync(config)) return;
-                        process = await WaitForProcessStartAsync(config.ProcessName!);
+                        process = await WaitForProcessStartAsync(config.ProcessName!, preExistingProcessIds);
                     }
                 }
                 else
-                    process = await WaitForProcessStartAsync(config.ProcessName);
+                    process = await WaitForProcessStartAsync(config.ProcessName, preExistingProcessIds);
             }
             else
             {
@@ -152,13 +158,16 @@ public sealed class GameLaunchService(
                     Verb = config.RunAsAdmin ? "runas" : null,
                 };
                 if (arguments is not null) startInfo.ArgumentList.Add(arguments);
+                preExistingProcessIds = GameProcessDetector.GetProcessIdsInDirectory(
+                    GameProcessDetector.GetDirectoryPrefix(installation.Path));
+                launchWindowTracker = StartLaunchWindowTracker(config, installation.Path, preExistingProcessIds);
                 process = new Process { StartInfo = startInfo };
                 process.Start();
 
-                if (!string.IsNullOrEmpty(config.ProcessName))
+                if (!string.IsNullOrEmpty(config.ProcessName) &&
+                    !ProcessMatchesConfiguredName(process, config.ProcessName))
                 {
-                    await Task.Delay(2000);
-                    process = await WaitForProcessStartAsync(config.ProcessName) ?? process;
+                    process = await WaitForProcessStartAsync(config.ProcessName, preExistingProcessIds) ?? process;
                 }
                 // 未指定进程名时直接跟踪启动的进程；若是启动器，
                 // RecordPlayTimeTask会在其退出后探测安装目录内新出现的进程并重新附着
@@ -177,27 +186,32 @@ public sealed class GameLaunchService(
             if (installation.Source is not null) sourceCollectionService.Save(installation.Source);
             await _gameService.SaveGalgameAsync(game);
 
-            _ = bgTaskService.AddBgTask(new RecordPlayTimeTask(game, process, installation.EntryId));
+            GameWindowSnapshot? initialWindowSnapshot = GameProcessDetector.TryGetPrimaryWindowSnapshot(process);
+            _ = bgTaskService.AddBgTask(new RecordPlayTimeTask(game, process, installation.EntryId,
+                preExistingProcessIds, processRelay, initialWindowSnapshot, launchWindowTracker));
+            // 计时任务接管启动窗口追踪器；启动服务提前结束时不能停止仍在等待接力的观察。
+            launchWindowTracker = null;
             // 即使当前没有生效规则，也保留轻量运行时任务，
             // 确保游戏运行期间首次启用或新增映射时可以立即生效。
-            _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process));
+            _ = bgTaskService.AddBgTask(new KeyMappingTask(game, process, game.KeyMappings,
+                preExistingProcessIds, processRelay));
             await jumpListService.AddToJumpListAsync(game);
             messenger.Send(new GalgamePlayedMessage(game));
 
             await Task.Delay(1000);
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysEnableMagpie) || game.EnableMagpie)
-                _ = bgTaskService.AddBgTask(new CallMagpieTask(game, process));
+                _ = bgTaskService.AddBgTask(new CallMagpieTask(game, process, processRelay));
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AlwaysMuteInBackground) ||
                 game.MuteInBackground)
-                _ = bgTaskService.AddBgTask(new GameMuteTask(game, process));
+                _ = bgTaskService.AddBgTask(new GameMuteTask(game, process, processRelay));
             if (await localSettingsService.ReadSettingAsync<bool>(KeyValues.AutoDetectSavePath) &&
                 config.DetectedSavePath is null)
                 _ = bgTaskService.AddBgTask(new GameSaveDetectorTask(game, installation));
-            if (!process.HasExited)
+            if (GameProcessDetector.IsAlive(process))
                 App.SetWindowMode(
                     await localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode));
 
-            await process.WaitForExitAsync();
+            await WaitForGameSessionEndAsync(process, processRelay);
         }
         catch (Win32Exception e) when (e.NativeErrorCode == 1223)
         {
@@ -209,6 +223,19 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+        finally
+        {
+            launchWindowTracker?.Stop();
+        }
+    }
+
+    private static GameLaunchWindowTracker? StartLaunchWindowTracker(LocalInstallationConfig config,
+        string installationPath, IReadOnlyCollection<int> preExistingProcessIds)
+    {
+        if (!config.DelayPlayTimeUntilMainWindow) return null;
+        GameLaunchWindowTracker tracker = new();
+        tracker.Start(GameProcessDetector.GetDirectoryPrefix(installationPath), preExistingProcessIds);
+        return tracker;
     }
 
     private bool TryEnterLaunch(Guid gameId)
@@ -227,16 +254,57 @@ public sealed class GameLaunchService(
             $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
-    private static async Task<Process?> WaitForProcessStartAsync(string processName)
+    private static async Task WaitForGameSessionEndAsync(Process initialProcess,
+        GameRuntimeProcessRelay processRelay)
     {
+        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess);
+        Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
+        Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
+        if (completed == initialProcessExit)
+        {
+            await initialProcessExit;
+            return;
+        }
+
+        Process? gameplayProcess = await gameplayProcessConfirmation;
+        if (gameplayProcess is null) return;
+        if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
+        {
+            await initialProcessExit;
+            return;
+        }
+        await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
+    }
+
+    private static async Task<Process?> WaitForProcessStartAsync(string processName,
+        IReadOnlyCollection<int>? excludedProcessIds = null)
+    {
+        HashSet<int> excluded = excludedProcessIds is null ? [] : new HashSet<int>(excludedProcessIds);
+        string normalizedProcessName = Path.GetFileNameWithoutExtension(processName);
         DateTime deadline = DateTime.UtcNow + ProcessWaitTimeout;
         do
         {
-            Process? process = Process.GetProcessesByName(processName).FirstOrDefault();
+            Process? process = Process.GetProcessesByName(normalizedProcessName)
+                .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
             if (process is not null) return process;
             await Task.Delay(250);
         } while (DateTime.UtcNow < deadline);
         return null;
+    }
+
+    private static bool ProcessMatchesConfiguredName(Process process, string configuredProcessName)
+    {
+        try
+        {
+            return string.Equals(
+                process.ProcessName,
+                Path.GetFileNameWithoutExtension(configuredProcessName),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static async Task<bool> SelectProcessAsync(LocalInstallationConfig config)

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -257,23 +257,42 @@ public sealed class GameLaunchService(
     private static async Task WaitForGameSessionEndAsync(Process initialProcess,
         GameRuntimeProcessRelay processRelay)
     {
-        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess);
-        Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
-        Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
-        if (completed == initialProcessExit)
+        using CancellationTokenSource initialProcessExitCancellation = new();
+        Task initialProcessExit = GameProcessDetector.WaitForExitSafelyAsync(initialProcess,
+            initialProcessExitCancellation.Token);
+        try
         {
-            await initialProcessExit;
-            return;
-        }
+            Task<Process?> gameplayProcessConfirmation = processRelay.WaitForConfirmationAsync();
+            Task completed = await Task.WhenAny(initialProcessExit, gameplayProcessConfirmation);
+            if (completed == initialProcessExit)
+            {
+                await initialProcessExit;
+                return;
+            }
 
-        Process? gameplayProcess = await gameplayProcessConfirmation;
-        if (gameplayProcess is null) return;
-        if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
-        {
-            await initialProcessExit;
-            return;
+            Process? gameplayProcess = await gameplayProcessConfirmation;
+            if (gameplayProcess is null) return;
+            if (GameProcessDetector.SafeGetId(gameplayProcess) == GameProcessDetector.SafeGetId(initialProcess))
+            {
+                await initialProcessExit;
+                return;
+            }
+
+            initialProcessExitCancellation.Cancel();
+            await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
         }
-        await GameProcessDetector.WaitForExitSafelyAsync(gameplayProcess);
+        finally
+        {
+            initialProcessExitCancellation.Cancel();
+            try
+            {
+                await initialProcessExit;
+            }
+            catch (OperationCanceledException) when (initialProcessExitCancellation.IsCancellationRequested)
+            {
+                // 进程接力后不再等待启动器退出，但仍观察已取消的等待任务。
+            }
+        }
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName,
@@ -284,9 +303,19 @@ public sealed class GameLaunchService(
         DateTime deadline = DateTime.UtcNow + ProcessWaitTimeout;
         do
         {
-            Process? process = Process.GetProcessesByName(normalizedProcessName)
-                .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
-            if (process is not null) return process;
+            Process[] candidates = Process.GetProcessesByName(normalizedProcessName);
+            Process? selected = null;
+            try
+            {
+                selected = candidates
+                    .FirstOrDefault(candidate => !excluded.Contains(GameProcessDetector.SafeGetId(candidate)));
+                if (selected is not null) return selected;
+            }
+            finally
+            {
+                foreach (Process candidate in candidates)
+                    if (!ReferenceEquals(candidate, selected)) candidate.Dispose();
+            }
             await Task.Delay(250);
         } while (DateTime.UtcNow < deadline);
         return null;

--- a/GalgameManager/Services/GameLaunchService.cs
+++ b/GalgameManager/Services/GameLaunchService.cs
@@ -26,6 +26,8 @@ public sealed class GameLaunchService(
     : IGameLaunchService
 {
     private static readonly TimeSpan ProcessWaitTimeout = TimeSpan.FromSeconds(60); // 等待目标游戏进程出现的最长时间
+    private readonly object _launchStateLock = new();
+    private readonly HashSet<Guid> _launchesInProgress = [];
     private readonly GalgameCollectionService _gameService =
         (GalgameCollectionService)gameCollectionService; // 逻辑游戏持久化与可执行文件选择服务
 
@@ -34,6 +36,35 @@ public sealed class GameLaunchService(
     {
         if (installation.Galgame != game || !installation.IsLocalInstallation)
             throw new ArgumentException("The installation does not belong to the game.", nameof(installation));
+
+        if (!TryEnterLaunch(game.Uuid))
+        {
+            ReportDuplicateLaunch(game, "launch request already in progress");
+            return;
+        }
+
+        try
+        {
+            await LaunchCoreAsync(game, installation);
+        }
+        finally
+        {
+            lock (_launchStateLock)
+            {
+                _launchesInProgress.Remove(game.Uuid);
+            }
+        }
+    }
+
+    private async Task LaunchCoreAsync(Galgame game, GalgameAndPath installation)
+    {
+        string gameKey = game.Uuid.ToString("D");
+        if (bgTaskService.GetBgTask<RecordPlayTimeTask>(gameKey) is not null)
+        {
+            ReportDuplicateLaunch(game, "play-time task already active");
+            return;
+        }
+
         if (!Directory.Exists(installation.Path))
         {
             infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
@@ -178,6 +209,22 @@ public sealed class GameLaunchService(
             infoService.Event(EventType.GalgameEvent, Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error,
                 "GalgamePage_Play_Error".GetLocalized() + e.Message, e);
         }
+    }
+
+    private bool TryEnterLaunch(Guid gameId)
+    {
+        lock (_launchStateLock)
+        {
+            return _launchesInProgress.Add(gameId);
+        }
+    }
+
+    private void ReportDuplicateLaunch(Galgame game, string reason)
+    {
+        infoService.Info(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            msg: "GalgamePage_Play_AlreadyRunning".GetLocalized(game.Name.Value ?? string.Empty));
+        infoService.Log(Microsoft.UI.Xaml.Controls.InfoBarSeverity.Informational,
+            $"Game launch ignored: reason={reason}, gameUuid={game.Uuid:D}");
     }
 
     private static async Task<Process?> WaitForProcessStartAsync(string processName)

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4159,4 +4159,232 @@ If play time can record correctly, just cancel this popup.
   <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
     <value>For installations that first show a disclaimer, patch notice, or launcher. Recording starts after a stable window transition; leave this off for games that open directly.</value>
   </data>
+  <data name="EditPlayTimeDialog_DateColumn.Text" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="EditPlayTimeDialog_Description.Text" xml:space="preserve">
+    <value>Daily totals include recorded sessions and any historical or manually added remainder. A total cannot be shorter than its sessions; use Add session on the play-time page when exact start and end times are needed.</value>
+  </data>
+  <data name="EditPlayTimeDialog_HourColumn.Text" xml:space="preserve">
+    <value>Hours</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteColumn.Text" xml:space="preserve">
+    <value>Minutes</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteDescription" xml:space="preserve">
+    <value>Edit daily totals in whole minutes. Click a launch segment in the details-page bar to edit or delete that segment. This dialog changes only historical or manually added time that is not assigned to a launch, and a daily total cannot be shorter than its launch records.</value>
+  </data>
+  <data name="EditPlayTimeDialog_PreciseDescription" xml:space="preserve">
+    <value>Daily totals include recorded sessions and any historical or manually added remainder. A total cannot be shorter than its sessions; use Add session on the play-time page when exact start and end times are needed.</value>
+  </data>
+  <data name="EditPlayTimeDialog_SecondColumn.Text" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionDateCannotDelete" xml:space="preserve">
+    <value>{0} contains recorded sessions, so its daily total cannot be deleted here. Delete those sessions first.</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionMinimum" xml:space="preserve">
+    <value>The total for {0} cannot be shorter than its recorded sessions ({1}). Edit or delete those sessions first.</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_AddTitle" xml:space="preserve">
+    <value>Add play session</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_DateRequired" xml:space="preserve">
+    <value>Select both a start date and an end date.</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Description.Text" xml:space="preserve">
+    <value>Editing the start and end replaces this launch with the complete selected interval, then updates the exact daily total and its legacy minute-compatible value.</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndBeforeStart" xml:space="preserve">
+    <value>The end time must be later than the start time.</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndDate.Header" xml:space="preserve">
+    <value>End date</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndTime.Text" xml:space="preserve">
+    <value>End time</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Hour.Header" xml:space="preserve">
+    <value>Hour</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Minute.Header" xml:space="preserve">
+    <value>Minute</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Overlap" xml:space="preserve">
+    <value>The selected interval overlaps an existing record. Adjust its start or end time.</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Second.Header" xml:space="preserve">
+    <value>Second</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartDate.Header" xml:space="preserve">
+    <value>Start date</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartTime.Text" xml:space="preserve">
+    <value>Start time</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Title" xml:space="preserve">
+    <value>Edit play session</value>
+  </data>
+  <data name="Hour" xml:space="preserve">
+    <value>h</value>
+  </data>
+  <data name="LessThanOneMinute" xml:space="preserve">
+    <value>Less than 1 minute</value>
+  </data>
+  <data name="PlayedTimePage_ActiveSessionCannotClose" xml:space="preserve">
+    <value>This session is still being recorded. Close the game normally before changing it.</value>
+  </data>
+  <data name="PlayedTimePage_ActivityIntervals.Text" xml:space="preserve">
+    <value>Effective timing segments</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.Label" xml:space="preserve">
+    <value>Add session</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Add a play session with an exact start and end time</value>
+  </data>
+  <data name="PlayedTimePage_CloseSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>End incomplete session</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionMessage" xml:space="preserve">
+    <value>End this session at its last recorded time ({0})?</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionTitle" xml:space="preserve">
+    <value>End incomplete session</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>Active or interrupted cross-day launch portion counted on {0} · {1}. Click to finish the entire record.</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentToolTip" xml:space="preserve">
+    <value>Portion of a cross-day launch counted on {0} · {1}. Click to edit only this day's portion.</value>
+  </data>
+  <data name="PlayedTimePage_DateSort.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Toggle date order</value>
+  </data>
+  <data name="PlayedTimePage_DateSortNewestFirst" xml:space="preserve">
+    <value>Newest first</value>
+  </data>
+  <data name="PlayedTimePage_DateSortOldestFirst" xml:space="preserve">
+    <value>Oldest first</value>
+  </data>
+  <data name="PlayedTimePage_DeleteCrossDayMinuteSessionMessage" xml:space="preserve">
+    <value>This launch spans multiple days. Delete only the portion counted on {0} ({1})? Portions on other dates remain unchanged, and this duration will be removed from the daily total.</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionButton" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionMessage" xml:space="preserve">
+    <value>Delete this launch record on {0} ({1})? Its duration will also be removed from the daily total.</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionTitle" xml:space="preserve">
+    <value>Delete launch record</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Delete session</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionMessage" xml:space="preserve">
+    <value>Delete the session from {0} to {1} ({2})? Its duration will also be removed from the native total.</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionTitle" xml:space="preserve">
+    <value>Delete play session</value>
+  </data>
+  <data name="PlayedTimePage_EditCrossDayMinuteSessionDescription" xml:space="preserve">
+    <value>This launch spans multiple days. Only the whole minutes counted on {0} will be changed; portions on other dates remain unchanged. The daily total will be adjusted by the same difference.</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionDescription" xml:space="preserve">
+    <value>Change the whole minutes counted for this launch on {0}. The daily total will be adjusted by the same difference.</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionTitle" xml:space="preserve">
+    <value>Edit launch duration</value>
+  </data>
+  <data name="PlayedTimePage_EditSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Edit session</value>
+  </data>
+  <data name="PlayedTimePage_LegacySummary" xml:space="preserve">
+    <value>Historical minute total without start/end boundaries: {0}</value>
+  </data>
+  <data name="PlayedTimePage_MinuteLegacySummary" xml:space="preserve">
+    <value>Historical or manually added time not assigned to a launch record: {0}. Click to edit the daily total.</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>Active or interrupted minute-mode launch · {0}. Click to finish this record.</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentToolTip" xml:space="preserve">
+    <value>Minute-mode launch {0} · {1}. Click to edit.</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSummary" xml:space="preserve">
+    <value>{0} days · minute-level timing</value>
+  </data>
+  <data name="PlayedTimePage_NoActivityIntervals.Text" xml:space="preserve">
+    <value>No effective timing segment was recorded for this launch.</value>
+  </data>
+  <data name="PlayedTimePage_NoSessions" xml:space="preserve">
+    <value>No play-time records yet.</value>
+  </data>
+  <data name="PlayedTimePage_OpenSessionCannotEdit" xml:space="preserve">
+    <value>A session that is still open cannot be edited or deleted. End it explicitly first.</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteOpenToolTip" xml:space="preserve">
+    <value>Active or interrupted precise-mode launch · {0}. Click to finish this record.</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteToolTip" xml:space="preserve">
+    <value>Precise-mode launch · {0}. Click to edit the complete launch record.</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSummary" xml:space="preserve">
+    <value>{0} dates · {1} play records · Precise total {2}</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.AutomationProperties.Name" xml:space="preserve">
+    <value>Explain the difference between precise total and total minutes</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.ToolTipService.ToolTip" xml:space="preserve">
+    <value>The precise total preserves the second remainder of every day before summing. The total minutes shown elsewhere truncates seconds for each day before adding the days, so the two totals may differ.</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelpFlyout.Text" xml:space="preserve">
+    <value>The precise total preserves the second remainder of every day before summing. The total minutes shown elsewhere truncates seconds for each day before adding the days, so the two totals may differ.</value>
+  </data>
+  <data name="PlayedTimePage_RecordingMode.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Switch between minute and precise timing. The Precise play time setting updates with this control; a running game uses the new mode on its next launch.</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModeMinute" xml:space="preserve">
+    <value>Minute timing</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModePrecise" xml:space="preserve">
+    <value>Precise timing</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.AutomationProperties.Name" xml:space="preserve">
+    <value>Refresh play-time details</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Refresh play-time details</value>
+  </data>
+  <data name="PlayedTimePage_SaveFailed" xml:space="preserve">
+    <value>Failed to save play sessions</value>
+  </data>
+  <data name="PlayedTimePage_SessionDescription.Text" xml:space="preserve">
+    <value>Each “Launch record” represents one complete game launch from entering the game until exit. Expand it to view the effective timing segments.</value>
+  </data>
+  <data name="PlayedTimePage_SessionImported" xml:space="preserve">
+    <value>Imported historical session</value>
+  </data>
+  <data name="PlayedTimePage_SessionManual" xml:space="preserve">
+    <value>Manually added session</value>
+  </data>
+  <data name="PlayedTimePage_SessionNative" xml:space="preserve">
+    <value>Launch record</value>
+  </data>
+  <data name="PlayedTimePage_SessionOpen" xml:space="preserve">
+    <value>Native session · active or interrupted</value>
+  </data>
+  <data name="PlayedTimePage_Summary" xml:space="preserve">
+    <value>{0} dates · {1} play records</value>
+  </data>
+  <data name="Second" xml:space="preserve">
+    <value>s</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Description" xml:space="preserve">
+    <value>When enabled, play time is recorded by the second with per-launch sessions and foreground activity intervals. When disabled, the original whole-minute sampling is used. The mode is locked when each game starts, so changes apply to the next launch.</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Title" xml:space="preserve">
+    <value>Enable precise play time</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4150,4 +4150,13 @@ If play time can record correctly, just cancel this popup.
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>“{0}” is already running or its play time is being recorded.</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>Waiting for the game window: {0} (launch dialogs are not counted)</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>Do not count launch dialogs</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>For installations that first show a disclaimer, patch notice, or launcher. Recording starts after a stable window transition; leave this off for games that open directly.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/en-US/Resources.resw
+++ b/GalgameManager/Strings/en-US/Resources.resw
@@ -4147,4 +4147,7 @@ If play time can record correctly, just cancel this popup.
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>No target library available. Add another library first.</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}” is already running or its play time is being recorded.</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4079,4 +4079,13 @@
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>ゲーム画面を待機中: {0}（起動時のダイアログは記録しません）</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>起動ダイアログをプレイ時間に含めない</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>最初に免責事項、パッチ案内、ランチャーを表示するインストール向けです。安定したウィンドウ切り替え後に記録を開始します。直接ゲームを開く場合はオフのままにしてください。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4088,4 +4088,232 @@
   <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
     <value>最初に免責事項、パッチ案内、ランチャーを表示するインストール向けです。安定したウィンドウ切り替え後に記録を開始します。直接ゲームを開く場合はオフのままにしてください。</value>
   </data>
+  <data name="EditPlayTimeDialog_DateColumn.Text" xml:space="preserve">
+    <value>日付</value>
+  </data>
+  <data name="EditPlayTimeDialog_Description.Text" xml:space="preserve">
+    <value>日別合計には、記録済みセッションと、起止時刻のない履歴・手動追加分が含まれます。合計をセッションより短くすることはできません。正確な開始・終了時刻を追加する場合は、プレイ時間ページの「セッションを追加」を使用してください。</value>
+  </data>
+  <data name="EditPlayTimeDialog_HourColumn.Text" xml:space="preserve">
+    <value>時間</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteColumn.Text" xml:space="preserve">
+    <value>分</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteDescription" xml:space="preserve">
+    <value>日ごとの合計を分単位で編集します。詳細ページの棒グラフにある起動区間をクリックすると、その区間を編集または削除できます。このダイアログは起動記録に属さない履歴または手動追加分だけを変更し、日ごとの合計を起動記録の合計より短くすることはできません。</value>
+  </data>
+  <data name="EditPlayTimeDialog_PreciseDescription" xml:space="preserve">
+    <value>日別合計には、記録済みセッションと、開始・終了時刻のない履歴または手動補正分が含まれます。合計をセッション合計より短くすることはできません。正確な開始・終了時刻が必要な場合は、プレイ時間ページの「セッションを追加」を使用してください。</value>
+  </data>
+  <data name="EditPlayTimeDialog_SecondColumn.Text" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionDateCannotDelete" xml:space="preserve">
+    <value>{0} には記録済みセッションがあるため、ここでは日別合計を削除できません。先に各セッションを削除してください。</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionMinimum" xml:space="preserve">
+    <value>{0} の合計時間は、記録済みセッションの合計（{1}）より短くできません。先に各セッションを編集または削除してください。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_AddTitle" xml:space="preserve">
+    <value>プレイセッションを追加</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_DateRequired" xml:space="preserve">
+    <value>開始日と終了日の両方を選択してください。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Description.Text" xml:space="preserve">
+    <value>開始・終了時刻を編集すると、この起動は指定した区間全体として再計算され、日別の秒単位集計と互換用の分単位値も更新されます。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndBeforeStart" xml:space="preserve">
+    <value>終了時刻は開始時刻より後にしてください。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndDate.Header" xml:space="preserve">
+    <value>終了日</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndTime.Text" xml:space="preserve">
+    <value>終了時刻</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Hour.Header" xml:space="preserve">
+    <value>时</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Minute.Header" xml:space="preserve">
+    <value>分</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Overlap" xml:space="preserve">
+    <value>選択した時間帯は既存の記録と重複しています。開始時刻または終了時刻を調整してください。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Second.Header" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartDate.Header" xml:space="preserve">
+    <value>開始日</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartTime.Text" xml:space="preserve">
+    <value>開始時刻</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Title" xml:space="preserve">
+    <value>プレイ区間を編集</value>
+  </data>
+  <data name="Hour" xml:space="preserve">
+    <value>時間</value>
+  </data>
+  <data name="LessThanOneMinute" xml:space="preserve">
+    <value>1分未満</value>
+  </data>
+  <data name="PlayedTimePage_ActiveSessionCannotClose" xml:space="preserve">
+    <value>この区間は現在記録中です。変更する前にゲームを通常終了してください。</value>
+  </data>
+  <data name="PlayedTimePage_ActivityIntervals.Text" xml:space="preserve">
+    <value>有効な計測区間</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.Label" xml:space="preserve">
+    <value>セッションを追加</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>開始・終了時刻を指定してプレイセッションを追加</value>
+  </data>
+  <data name="PlayedTimePage_CloseSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>未完了の区間を終了</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionMessage" xml:space="preserve">
+    <value>最後に記録された時刻（{0}）でこの区間を終了しますか？</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionTitle" xml:space="preserve">
+    <value>未完了の区間を終了</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>記録中または中断された日付をまたぐ起動のうち {0} に記録された部分・{1}。クリックすると記録全体を終了できます。</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentToolTip" xml:space="preserve">
+    <value>日付をまたぐ起動のうち {0} に記録された部分・{1}。クリックするとこの日の部分だけを編集できます。</value>
+  </data>
+  <data name="PlayedTimePage_DateSort.ToolTipService.ToolTip" xml:space="preserve">
+    <value>日付の並び順を切り替え</value>
+  </data>
+  <data name="PlayedTimePage_DateSortNewestFirst" xml:space="preserve">
+    <value>新しい順</value>
+  </data>
+  <data name="PlayedTimePage_DateSortOldestFirst" xml:space="preserve">
+    <value>古い順</value>
+  </data>
+  <data name="PlayedTimePage_DeleteCrossDayMinuteSessionMessage" xml:space="preserve">
+    <value>これは日付をまたぐ起動記録です。{0} に記録された部分（{1}）だけを削除しますか？ほかの日付の部分は残り、対応する時間が日別合計から差し引かれます。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionButton" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionMessage" xml:space="preserve">
+    <value>{0} のこの起動記録（{1}）を削除しますか？対応する時間も日別合計から差し引かれます。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionTitle" xml:space="preserve">
+    <value>起動記録を削除</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>区間を削除</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionMessage" xml:space="preserve">
+    <value>{0} から {1} までの区間（{2}）を削除しますか？ネイティブの合計時間からも差し引かれます。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionTitle" xml:space="preserve">
+    <value>プレイ区間を削除</value>
+  </data>
+  <data name="PlayedTimePage_EditCrossDayMinuteSessionDescription" xml:space="preserve">
+    <value>これは日付をまたぐ起動記録です。{0} に記録された分数だけを変更し、ほかの日付の部分は変更しません。日別合計も同じ差分だけ調整されます。</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionDescription" xml:space="preserve">
+    <value>{0} のこの起動で記録した分数を変更します。日別合計も同じ差分だけ調整されます。</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionTitle" xml:space="preserve">
+    <value>起動時間を編集</value>
+  </data>
+  <data name="PlayedTimePage_EditSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>区間を編集</value>
+  </data>
+  <data name="PlayedTimePage_LegacySummary" xml:space="preserve">
+    <value>開始・終了時刻のない過去の分単位集計：{0}</value>
+  </data>
+  <data name="PlayedTimePage_MinuteLegacySummary" xml:space="preserve">
+    <value>起動記録に紐づかない履歴または手動補正時間：{0}。クリックして日別合計を編集できます。</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>記録中または中断された分単位モードの起動・{0}。クリックしてこの記録を終了できます。</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentToolTip" xml:space="preserve">
+    <value>分単位モードの第{0}回起動・{1}。クリックして編集できます。</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSummary" xml:space="preserve">
+    <value>{0} 日 · 分単位計測</value>
+  </data>
+  <data name="PlayedTimePage_NoActivityIntervals.Text" xml:space="preserve">
+    <value>この起動では有効な計測区間が記録されていません。</value>
+  </data>
+  <data name="PlayedTimePage_NoSessions" xml:space="preserve">
+    <value>プレイ時間の記録はまだありません。</value>
+  </data>
+  <data name="PlayedTimePage_OpenSessionCannotEdit" xml:space="preserve">
+    <value>記録中の区間は編集または削除できません。先に明示的に終了してください。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteOpenToolTip" xml:space="preserve">
+    <value>記録中または中断された秒単位モードの起動・{0}。クリックしてこの記録を終了できます。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteToolTip" xml:space="preserve">
+    <value>秒単位モードの起動記録・{0}。クリックすると起動記録全体を編集できます。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSummary" xml:space="preserve">
+    <value>{0} 日 · {1} 件のプレイ記録 · 秒単位合計 {2}</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.AutomationProperties.Name" xml:space="preserve">
+    <value>秒単位合計と合計分数の差について</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.ToolTipService.ToolTip" xml:space="preserve">
+    <value>秒単位合計は各日の秒数を保持したまま集計します。一方、ほかの画面に表示される合計分数は日ごとに秒数を切り捨ててから加算するため、両者は一致しない場合があります。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelpFlyout.Text" xml:space="preserve">
+    <value>秒単位合計は各日の秒数を保持したまま合計します。他の画面に表示される合計分数は、日ごとに秒数を切り捨ててから加算するため、両者に差が生じる場合があります。</value>
+  </data>
+  <data name="PlayedTimePage_RecordingMode.ToolTipService.ToolTip" xml:space="preserve">
+    <value>分単位計測と秒単位計測を切り替えます。設定画面の「正確なプレイ時間」と連動し、起動中のゲームには次回起動時から適用されます。</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModeMinute" xml:space="preserve">
+    <value>分単位計測</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModePrecise" xml:space="preserve">
+    <value>秒単位計測</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.AutomationProperties.Name" xml:space="preserve">
+    <value>プレイ時間の詳細を更新</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.ToolTipService.ToolTip" xml:space="preserve">
+    <value>プレイ時間の詳細を更新</value>
+  </data>
+  <data name="PlayedTimePage_SaveFailed" xml:space="preserve">
+    <value>プレイ区間を保存できませんでした</value>
+  </data>
+  <data name="PlayedTimePage_SessionDescription.Text" xml:space="preserve">
+    <value>「起動記録」は、ゲーム開始から終了までの1回の起動全体を表します。展開すると有効な計測区間を確認できます。</value>
+  </data>
+  <data name="PlayedTimePage_SessionImported" xml:space="preserve">
+    <value>インポートした過去の区間</value>
+  </data>
+  <data name="PlayedTimePage_SessionManual" xml:space="preserve">
+    <value>手動追加セッション</value>
+  </data>
+  <data name="PlayedTimePage_SessionNative" xml:space="preserve">
+    <value>起動記録</value>
+  </data>
+  <data name="PlayedTimePage_SessionOpen" xml:space="preserve">
+    <value>ネイティブ区間 · 記録中または異常中断</value>
+  </data>
+  <data name="PlayedTimePage_Summary" xml:space="preserve">
+    <value>{0} 日 · {1} 件のプレイ記録</value>
+  </data>
+  <data name="Second" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Description" xml:space="preserve">
+    <value>有効にすると、プレイ時間を秒単位で記録し、起動ごとのセッションとフォアグラウンド計測区間を保存します。無効にすると、従来の1分単位のサンプリングを使用します。モードはゲーム起動時に固定され、変更は次回起動から反映されます。</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Title" xml:space="preserve">
+    <value>正確なプレイ時間を有効にする</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/ja-JP/Resources.resw
+++ b/GalgameManager/Strings/ja-JP/Resources.resw
@@ -4076,4 +4076,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>移動先のライブラリがありません。先に別のライブラリを追加してください。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>「{0}」はすでに実行中か、プレイ時間を記録中です。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5071,4 +5071,232 @@
   <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
     <value>适用于先显示声明、补丁说明或启动器的安装实例。开启后会等到窗口发生稳定切换再开始计时；直接进入游戏的实例请保持关闭。</value>
   </data>
+  <data name="EditPlayTimeDialog_DateColumn.Text" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="EditPlayTimeDialog_Description.Text" xml:space="preserve">
+    <value>日汇总包含已有游玩时段，以及没有起止边界的历史或手工补正余量。汇总不能小于时段总和；需要精确起止时间时，请使用游玩时间页面的“新增时段”。</value>
+  </data>
+  <data name="EditPlayTimeDialog_HourColumn.Text" xml:space="preserve">
+    <value>小时</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteColumn.Text" xml:space="preserve">
+    <value>分钟</value>
+  </data>
+  <data name="EditPlayTimeDialog_MinuteDescription" xml:space="preserve">
+    <value>按整数分钟编辑每日汇总。单击详情页柱状图中的启动分段，可编辑或删除该段。本对话框只调整未归入启动记录的历史或手工余量，每日总时长不能小于各启动记录之和。</value>
+  </data>
+  <data name="EditPlayTimeDialog_PreciseDescription" xml:space="preserve">
+    <value>日汇总包含已有游玩时段，以及没有起止边界的历史或手工补正余量。汇总不能小于时段总和；需要精确起止时间时，请使用游玩时间页面的“新增时段”。</value>
+  </data>
+  <data name="EditPlayTimeDialog_SecondColumn.Text" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionDateCannotDelete" xml:space="preserve">
+    <value>{0} 已有游玩时段，不能在这里删除日汇总。请先删除对应时段。</value>
+  </data>
+  <data name="EditPlayTimeDialog_SessionMinimum" xml:space="preserve">
+    <value>{0} 的汇总时长不能小于已有时段总和（{1}）。请先编辑或删除对应时段。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_AddTitle" xml:space="preserve">
+    <value>新增游玩时段</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_DateRequired" xml:space="preserve">
+    <value>请选择开始日期和结束日期。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Description.Text" xml:space="preserve">
+    <value>编辑开始和结束时间后，本次启动会按所选完整区间重新计算，并同步更新秒级日汇总及兼容旧版的分钟数。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndBeforeStart" xml:space="preserve">
+    <value>结束时间必须晚于开始时间。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndDate.Header" xml:space="preserve">
+    <value>结束日期</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_EndTime.Text" xml:space="preserve">
+    <value>结束时间</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Hour.Header" xml:space="preserve">
+    <value>时</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Minute.Header" xml:space="preserve">
+    <value>分</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Overlap" xml:space="preserve">
+    <value>所选时段与已有记录重叠，请调整开始或结束时间。</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Second.Header" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartDate.Header" xml:space="preserve">
+    <value>开始日期</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_StartTime.Text" xml:space="preserve">
+    <value>开始时间</value>
+  </data>
+  <data name="EditPlayTimeSessionDialog_Title" xml:space="preserve">
+    <value>编辑游玩时段</value>
+  </data>
+  <data name="Hour" xml:space="preserve">
+    <value>小时</value>
+  </data>
+  <data name="LessThanOneMinute" xml:space="preserve">
+    <value>不足 1 分钟</value>
+  </data>
+  <data name="PlayedTimePage_ActiveSessionCannotClose" xml:space="preserve">
+    <value>这个时段仍在实时记录，请先正常退出游戏再进行修改。</value>
+  </data>
+  <data name="PlayedTimePage_ActivityIntervals.Text" xml:space="preserve">
+    <value>有效计时片段</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.Label" xml:space="preserve">
+    <value>新增时段</value>
+  </data>
+  <data name="PlayedTimePage_AddSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>新增带有精确起止时间的游玩时段</value>
+  </data>
+  <data name="PlayedTimePage_CloseSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>结束未完成时段</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionMessage" xml:space="preserve">
+    <value>要在最后记录时间（{0}）结束这个时段吗？</value>
+  </data>
+  <data name="PlayedTimePage_CloseSessionTitle" xml:space="preserve">
+    <value>结束未完成时段</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>正在记录或异常中断的跨日启动在 {0} 当天计入的部分 · {1}；单击可结束整条记录</value>
+  </data>
+  <data name="PlayedTimePage_CrossDayMinuteSegmentToolTip" xml:space="preserve">
+    <value>跨日启动在 {0} 当天计入的部分 · {1}；单击只编辑当天部分</value>
+  </data>
+  <data name="PlayedTimePage_DateSort.ToolTipService.ToolTip" xml:space="preserve">
+    <value>切换日期排序</value>
+  </data>
+  <data name="PlayedTimePage_DateSortNewestFirst" xml:space="preserve">
+    <value>最新在前</value>
+  </data>
+  <data name="PlayedTimePage_DateSortOldestFirst" xml:space="preserve">
+    <value>最早在前</value>
+  </data>
+  <data name="PlayedTimePage_DeleteCrossDayMinuteSessionMessage" xml:space="preserve">
+    <value>这是一条跨日启动记录。确定删除 {0} 当天计入的部分（{1}）吗？其他日期的部分保持不变，对应时长会从当天总计中扣除。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionButton" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionMessage" xml:space="preserve">
+    <value>删除 {0} 的这次启动记录（{1}）？对应时长也会从当天总计中扣除。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteMinuteSessionTitle" xml:space="preserve">
+    <value>删除单次启动记录</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>删除时段</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionMessage" xml:space="preserve">
+    <value>确定删除 {0} 至 {1} 的时段（{2}）吗？对应时长也会从原生总时长中扣除。</value>
+  </data>
+  <data name="PlayedTimePage_DeleteSessionTitle" xml:space="preserve">
+    <value>删除游玩时段</value>
+  </data>
+  <data name="PlayedTimePage_EditCrossDayMinuteSessionDescription" xml:space="preserve">
+    <value>这是一条跨日启动记录。当前只修改 {0} 当天计入的整分钟数，其他日期的部分保持不变；当天总时长会按相同差额同步调整。</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionDescription" xml:space="preserve">
+    <value>修改 {0} 这次启动计入的整分钟数。当天总时长会按相同差额同步调整。</value>
+  </data>
+  <data name="PlayedTimePage_EditMinuteSessionTitle" xml:space="preserve">
+    <value>编辑单次启动时长</value>
+  </data>
+  <data name="PlayedTimePage_EditSession.ToolTipService.ToolTip" xml:space="preserve">
+    <value>编辑时段</value>
+  </data>
+  <data name="PlayedTimePage_LegacySummary" xml:space="preserve">
+    <value>没有开始/结束边界的历史分钟汇总：{0}</value>
+  </data>
+  <data name="PlayedTimePage_MinuteLegacySummary" xml:space="preserve">
+    <value>未归入单次启动记录的历史或手工时长：{0}；单击可编辑日汇总</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentOpenToolTip" xml:space="preserve">
+    <value>正在记录或异常中断的分钟模式启动 · {0}；单击可结束此记录</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSegmentToolTip" xml:space="preserve">
+    <value>分钟模式第 {0} 次启动 · {1}；单击可编辑</value>
+  </data>
+  <data name="PlayedTimePage_MinuteSummary" xml:space="preserve">
+    <value>{0} 个日期 · 分钟级计时</value>
+  </data>
+  <data name="PlayedTimePage_NoActivityIntervals.Text" xml:space="preserve">
+    <value>本次启动尚未记录到有效计时片段</value>
+  </data>
+  <data name="PlayedTimePage_NoSessions" xml:space="preserve">
+    <value>暂无游玩时间记录。</value>
+  </data>
+  <data name="PlayedTimePage_OpenSessionCannotEdit" xml:space="preserve">
+    <value>仍处于开放状态的时段不能编辑或删除，请先明确结束该时段。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteOpenToolTip" xml:space="preserve">
+    <value>正在记录或异常中断的秒级启动记录 · {0}；单击可结束此记录</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSegmentMinuteToolTip" xml:space="preserve">
+    <value>秒级启动记录 · {0}；单击可编辑完整启动记录</value>
+  </data>
+  <data name="PlayedTimePage_PreciseSummary" xml:space="preserve">
+    <value>{0} 个日期 · {1} 条游玩记录 · 秒级总计 {2}</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.AutomationProperties.Name" xml:space="preserve">
+    <value>说明秒级总计与总分钟数的差值</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelp.ToolTipService.ToolTip" xml:space="preserve">
+    <value>秒级总计会保留每天的秒数后再汇总；其他界面显示的总分钟数会先分别舍去每天的秒数再相加，因此两者可能存在差值。</value>
+  </data>
+  <data name="PlayedTimePage_PreciseTotalHelpFlyout.Text" xml:space="preserve">
+    <value>秒级总计会保留每天的秒数后再汇总；其他界面显示的总分钟数会先分别舍去每天的秒数再相加，因此两者可能存在差值。</value>
+  </data>
+  <data name="PlayedTimePage_RecordingMode.ToolTipService.ToolTip" xml:space="preserve">
+    <value>切换分钟级与秒级计时；设置页中的“精确游玩时间”会同步更新，正在运行的游戏从下次启动起应用</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModeMinute" xml:space="preserve">
+    <value>分钟级计时</value>
+  </data>
+  <data name="PlayedTimePage_RecordingModePrecise" xml:space="preserve">
+    <value>秒级计时</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.AutomationProperties.Name" xml:space="preserve">
+    <value>刷新游玩时间详情</value>
+  </data>
+  <data name="PlayedTimePage_Refresh.ToolTipService.ToolTip" xml:space="preserve">
+    <value>刷新游玩时间详情</value>
+  </data>
+  <data name="PlayedTimePage_SaveFailed" xml:space="preserve">
+    <value>保存游玩时段失败</value>
+  </data>
+  <data name="PlayedTimePage_SessionDescription.Text" xml:space="preserve">
+    <value>每条“单次启动记录”代表一次从进入游戏到退出的完整启动过程，展开后可查看其中的有效计时片段。</value>
+  </data>
+  <data name="PlayedTimePage_SessionImported" xml:space="preserve">
+    <value>导入的历史时段</value>
+  </data>
+  <data name="PlayedTimePage_SessionManual" xml:space="preserve">
+    <value>手动新增时段</value>
+  </data>
+  <data name="PlayedTimePage_SessionNative" xml:space="preserve">
+    <value>单次启动记录</value>
+  </data>
+  <data name="PlayedTimePage_SessionOpen" xml:space="preserve">
+    <value>原生时段 · 正在记录或异常中断</value>
+  </data>
+  <data name="PlayedTimePage_Summary" xml:space="preserve">
+    <value>{0} 个日期 · {1} 条游玩记录</value>
+  </data>
+  <data name="Second" xml:space="preserve">
+    <value>秒</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Description" xml:space="preserve">
+    <value>开启后按秒采集游玩时长，并记录每次启动及前台计时片段；关闭后沿用原版的整分钟采样。模式在每次启动游戏时锁定，切换后从下次启动生效。</value>
+  </data>
+  <data name="SettingsPage_Game_PrecisePlayTime.Title" xml:space="preserve">
+    <value>启用精确游玩时间</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5059,4 +5059,7 @@
   <data name="ChangeSourceDialog_NoTargetSource" xml:space="preserve">
     <value>没有可移动到的目标库，请先添加另一个库。</value>
   </data>
+  <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
+    <value>“{0}”已在运行或正在记录游玩时间。</value>
+  </data>
 </root>

--- a/GalgameManager/Strings/zh-CN/Resources.resw
+++ b/GalgameManager/Strings/zh-CN/Resources.resw
@@ -5062,4 +5062,13 @@
   <data name="GalgamePage_Play_AlreadyRunning" xml:space="preserve">
     <value>“{0}”已在运行或正在记录游玩时间。</value>
   </data>
+  <data name="RecordPlayTimeTask_WaitingForMainWindow" xml:space="preserve">
+    <value>正在等待游戏主窗口：{0}（声明或启动器窗口期间暂不计时）</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Title" xml:space="preserve">
+    <value>启动弹窗期间暂不计时</value>
+  </data>
+  <data name="GalgameSettingPage_DelayPlayTimeUntilMainWindow.Description" xml:space="preserve">
+    <value>适用于先显示声明、补丁说明或启动器的安装实例。开启后会等到窗口发生稳定切换再开始计时；直接进入游戏的实例请保持关闭。</value>
+  </data>
 </root>

--- a/GalgameManager/ViewModels/PlayedTimeViewModel.cs
+++ b/GalgameManager/ViewModels/PlayedTimeViewModel.cs
@@ -1,47 +1,88 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GalgameManager.Contracts.Services;
 using GalgameManager.Contracts.ViewModels;
+using GalgameManager.Core.Helpers;
 using GalgameManager.Enums;
 using GalgameManager.Helpers;
+using GalgameManager.Helpers.Converter;
 using GalgameManager.Models;
+using GalgameManager.Models.BgTasks;
 using GalgameManager.Services;
 using GalgameManager.Views.Dialog;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace GalgameManager.ViewModels;
 
 public partial class PlayedTimeViewModel : ObservableObject, INavigationAware
 {
+    private const double HistoricalSegmentOpacity = 0.42;
+    private const double LaunchSegmentOpacity = 0.82;
+
     public Galgame Game = new();
-    public ObservableCollection<PlayTimeViewModelItem> Items { get; } = new();
+    public ObservableCollection<PlayTimeDayViewModelItem> Items { get; } = new();
+    [ObservableProperty] private string _summary = string.Empty;
+    [ObservableProperty] private string _dateSortLabel = string.Empty;
+    [ObservableProperty] private string _recordingModeLabel = string.Empty;
+    [ObservableProperty] private bool _precisePlayTimeEnabled;
+    [ObservableProperty] private Visibility _preciseModeVisibility = Visibility.Collapsed;
+
     private readonly INavigationService _navigationService;
     private readonly IPvnService _pvnService;
+    private readonly IInfoService _infoService;
+    private readonly ILocalSettingsService _localSettingsService;
+    private readonly IBgTaskService _bgTaskService;
     private readonly GalgameCollectionService _galgameCollectionService;
-    private double _totalWidth; // 柱状图绘制区域总宽度
-    
-    public PlayedTimeViewModel(INavigationService navigationService, IGalgameCollectionService gameCollectionService,
-        IPvnService pvnService)
+    private double _totalWidth;
+    private bool _precisePlayTime;
+    private bool _timeAsHour;
+    private bool _dateDescending;
+
+    public PlayedTimeViewModel(
+        INavigationService navigationService,
+        IGalgameCollectionService gameCollectionService,
+        IPvnService pvnService,
+        IInfoService infoService,
+        ILocalSettingsService localSettingsService,
+        IBgTaskService bgTaskService)
     {
         _navigationService = navigationService;
         _galgameCollectionService = (gameCollectionService as GalgameCollectionService)!;
         _pvnService = pvnService;
+        _infoService = infoService;
+        _localSettingsService = localSettingsService;
+        _bgTaskService = bgTaskService;
     }
 
-    public void OnNavigatedTo(object parameter)
+    public async void OnNavigatedTo(object parameter)
     {
         Debug.Assert(parameter is Galgame);
         if (parameter is not Galgame galgame) return;
         Game = galgame;
-        Update();
+        _precisePlayTime = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.PrecisePlayTime);
+        UpdateRecordingModeUi();
+        _timeAsHour = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.TimeAsHour);
+        _dateDescending = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.PlayedTimeDateDescending);
+        try
+        {
+            if (_precisePlayTime && PlayTimeSessionHelper.ReconcileCountedSessionTotals(Game))
+                await SaveAndSyncAsync();
+        }
+        catch (Exception ex)
+        {
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+        Update(preserveExpandedState: false);
     }
 
     public void OnNavigatedFrom()
     {
     }
-    
+
     [RelayCommand]
     private void OnPageSizeChanged(SizeChangedEventArgs e)
     {
@@ -49,56 +90,829 @@ public partial class PlayedTimeViewModel : ObservableObject, INavigationAware
         UpdateWidth();
     }
 
-    /// 更新柱状图
-    private void Update()
+    private void Update(bool preserveExpandedState = true)
     {
-        Items.Clear();
-        foreach (var (date, playTime) in Game.PlayedTime)
-            Items.Add(new(date, playTime));
+        HashSet<DateTime> expandedDates = preserveExpandedState
+            ? Items.Where(item => item.IsExpanded).Select(item => item.DateValue).ToHashSet()
+            : [];
+        HashSet<(Guid SessionId, DateTime Date)> expandedSessions = preserveExpandedState
+            ? Items.SelectMany(item => item.Sessions)
+                .Where(item => item.IsExpanded)
+                .Select(item => (item.SessionId, item.DateValue))
+                .ToHashSet()
+            : [];
+        List<PlayTimeDayViewModelItem> updatedItems = [];
+        Dictionary<Guid, PlayTimeSession> sessionsById = Game.PlayTimeSessions
+            .Where(session => session.Kind != PlayTimeSessionKind.MinuteSampled)
+            .GroupBy(session => session.Id)
+            .ToDictionary(group => group.Key, group => group.First());
+        IReadOnlyList<PlayTimeDaySegment> sessionSegments =
+            PlayTimeSessionHelper.GetPreciseSessionDaySegments(Game);
+
+        IEnumerable<string> dateKeys = Game.PlayedTime.Keys.Concat(Game.PlayedTimeSeconds.Keys);
+        HashSet<DateTime> dates = dateKeys
+            .Select(Utils.TryParseDateGuessCulture)
+            .Where(date => date.Year > 1900)
+            .Select(date => date.Date)
+            .ToHashSet();
+        if (_precisePlayTime)
+            foreach (PlayTimeDaySegment segment in sessionSegments) dates.Add(segment.Date);
+
+        IEnumerable<DateTime> orderedDates = _dateDescending
+            ? dates.OrderByDescending(date => date)
+            : dates.OrderBy(date => date);
+        foreach (DateTime date in orderedDates)
+        {
+            PlayTimeDaySegment[] daySessions = sessionSegments
+                .Where(segment => segment.Date == date)
+                .OrderBy(segment => segment.StartedAt)
+                .ToArray();
+            IReadOnlyList<MinutePlayTimeDaySegment> minuteSegments =
+                PlayTimeSessionHelper.GetMinuteSampleSegmentsForDay(Game, date);
+            long totalSeconds = PlayTimeSessionHelper.GetDaySeconds(Game, date);
+            PlayTimeDayBreakdown breakdown = PlayTimeSessionHelper.GetDayDisplayBreakdown(Game, date);
+            long sampledTotal = breakdown.MinuteSampleSeconds;
+            long legacySeconds = breakdown.UnsegmentedSeconds;
+            bool showSecondPrecision = _precisePlayTime &&
+                                       daySessions.Any(segment => segment.CountsTowardPlayTime);
+
+            List<PlayTimeBarSegmentViewModelItem> bars = [];
+            if (!_precisePlayTime)
+            {
+                AddMinuteSampleBars(bars, minuteSegments, sampledTotal);
+                AddPreciseSessionBars(bars, daySessions, sessionsById, true);
+                if (legacySeconds > 0)
+                    bars.Add(new PlayTimeBarSegmentViewModelItem(
+                        legacySeconds,
+                            HistoricalSegmentOpacity,
+                            "PlayedTimePage_MinuteLegacySummary".GetLocalized(
+                                TimeToDisplayTimeConverter.ConvertMinuteModeSeconds(
+                                    legacySeconds, _timeAsHour)),
+                            Edit));
+            }
+            else
+            {
+                if (legacySeconds > 0)
+                    bars.Add(new PlayTimeBarSegmentViewModelItem(
+                        legacySeconds,
+                        HistoricalSegmentOpacity,
+                        LegacyTextForBar(legacySeconds)));
+                AddMinuteSampleBars(bars, minuteSegments, sampledTotal);
+                AddPreciseSessionBars(bars, daySessions, sessionsById, false);
+            }
+
+            List<PlayTimeSessionViewModelItem> rows = [];
+            foreach (PlayTimeDaySegment segment in _precisePlayTime ? daySessions : [])
+            {
+                if (!sessionsById.TryGetValue(segment.SessionId, out PlayTimeSession? session)) continue;
+                rows.Add(new PlayTimeSessionViewModelItem(
+                    session,
+                    segment,
+                    EditSessionAsync,
+                    DeleteSessionAsync,
+                    CloseSessionAsync,
+                    _timeAsHour,
+                    expandedSessions.Contains((segment.SessionId, segment.Date))));
+            }
+
+            updatedItems.Add(new PlayTimeDayViewModelItem(
+                date,
+                totalSeconds,
+                legacySeconds,
+                bars,
+                rows,
+                _precisePlayTime,
+                showSecondPrecision,
+                _timeAsHour,
+                expandedDates.Contains(date)));
+        }
+
+        if (preserveExpandedState)
+            SynchronizeItems(updatedItems);
+        else
+        {
+            Items.Clear();
+            foreach (PlayTimeDayViewModelItem item in updatedItems) Items.Add(item);
+        }
+
+        Summary = Items.Count == 0
+            ? "PlayedTimePage_NoSessions".GetLocalized()
+            : _precisePlayTime
+                ? "PlayedTimePage_PreciseSummary".GetLocalized(
+                    Items.Count,
+                    Game.PlayTimeSessions.Count,
+                    TimeToDisplayTimeConverter.ConvertSeconds(
+                        PlayTimeSessionHelper.GetTotalSeconds(Game), _timeAsHour))
+                : "PlayedTimePage_MinuteSummary".GetLocalized(Items.Count);
+        DateSortLabel = (_dateDescending
+            ? "PlayedTimePage_DateSortNewestFirst"
+            : "PlayedTimePage_DateSortOldestFirst").GetLocalized();
         UpdateWidth();
     }
-    
+
+    private void SynchronizeItems(IReadOnlyList<PlayTimeDayViewModelItem> updatedItems)
+    {
+        for (int targetIndex = 0; targetIndex < updatedItems.Count; targetIndex++)
+        {
+            PlayTimeDayViewModelItem updated = updatedItems[targetIndex];
+            int existingIndex = -1;
+            for (int index = targetIndex; index < Items.Count; index++)
+            {
+                if (Items[index].DateValue != updated.DateValue) continue;
+                existingIndex = index;
+                break;
+            }
+
+            if (existingIndex < 0)
+            {
+                Items.Insert(targetIndex, updated);
+                continue;
+            }
+
+            if (existingIndex != targetIndex) Items.Move(existingIndex, targetIndex);
+            Items[targetIndex].ApplySnapshot(updated);
+        }
+
+        while (Items.Count > updatedItems.Count) Items.RemoveAt(Items.Count - 1);
+    }
+
+    private void AddMinuteSampleBars(
+        List<PlayTimeBarSegmentViewModelItem> bars,
+        IReadOnlyList<MinutePlayTimeDaySegment> minuteSegments,
+        long visibleTotal)
+    {
+        long remainingSampled = visibleTotal;
+        int minuteIndex = 0;
+        foreach (MinutePlayTimeDaySegment segment in minuteSegments)
+        {
+            minuteIndex++;
+            long visibleDuration = Math.Min(segment.Minutes * 60L, remainingSampled);
+            if (visibleDuration <= 0) continue;
+
+            string duration = FormatMinuteSegmentDuration(segment.Minutes);
+            string toolTip = segment.SpansMultipleDays
+                ? segment.IsOpen
+                    ? "PlayedTimePage_CrossDayMinuteSegmentOpenToolTip".GetLocalized(
+                        segment.Date.ToStringDefault(), duration)
+                    : "PlayedTimePage_CrossDayMinuteSegmentToolTip".GetLocalized(
+                        segment.Date.ToStringDefault(), duration)
+                : segment.IsOpen
+                    ? "PlayedTimePage_MinuteSegmentOpenToolTip".GetLocalized(duration)
+                    : "PlayedTimePage_MinuteSegmentToolTip".GetLocalized(minuteIndex, duration);
+            Func<Task> activate = segment.IsOpen
+                ? () => CloseMinuteSessionAsync(segment)
+                : () => EditMinuteSessionAsync(segment);
+            bars.Add(new PlayTimeBarSegmentViewModelItem(
+                visibleDuration,
+                LaunchSegmentOpacity,
+                toolTip,
+                activate));
+            remainingSampled -= visibleDuration;
+        }
+    }
+
+    private void AddPreciseSessionBars(
+        List<PlayTimeBarSegmentViewModelItem> bars,
+        IEnumerable<PlayTimeDaySegment> daySessions,
+        IReadOnlyDictionary<Guid, PlayTimeSession> sessionsById,
+        bool interactive)
+    {
+        foreach (PlayTimeDaySegment segment in daySessions.Where(segment => segment.CountsTowardPlayTime))
+        {
+            if (!interactive)
+            {
+                bars.Add(new PlayTimeBarSegmentViewModelItem(
+                    segment.DurationSeconds,
+                    LaunchSegmentOpacity,
+                    TimeToDisplayTimeConverter.ConvertSeconds(segment.DurationSeconds, _timeAsHour)));
+                continue;
+            }
+
+            if (!sessionsById.TryGetValue(segment.SessionId, out PlayTimeSession? session)) continue;
+            string duration = TimeToDisplayTimeConverter.ConvertMinuteModeSeconds(
+                segment.DurationSeconds, _timeAsHour);
+            string toolTip = (session.IsOpen
+                    ? "PlayedTimePage_PreciseSegmentMinuteOpenToolTip"
+                    : "PlayedTimePage_PreciseSegmentMinuteToolTip")
+                .GetLocalized(duration);
+            Func<Task> activate = session.IsOpen
+                ? () => CloseSessionAsync(session)
+                : () => EditSessionAsync(session);
+            bars.Add(new PlayTimeBarSegmentViewModelItem(
+                segment.DurationSeconds,
+                LaunchSegmentOpacity,
+                toolTip,
+                activate));
+        }
+    }
+
+    private string LegacyTextForBar(long seconds) =>
+        "PlayedTimePage_LegacySummary".GetLocalized(
+            TimeToDisplayTimeConverter.ConvertWholeMinuteSecondsWithUnits(seconds, _timeAsHour));
+
+    private string FormatMinuteSegmentDuration(int minutes) =>
+        _precisePlayTime
+            ? TimeToDisplayTimeConverter.ConvertWholeMinutesWithUnits(minutes, _timeAsHour)
+            : TimeToDisplayTimeConverter.ConvertMinutes(minutes, _timeAsHour);
+
+    private void UpdateRecordingModeUi()
+    {
+        PrecisePlayTimeEnabled = _precisePlayTime;
+        PreciseModeVisibility = _precisePlayTime ? Visibility.Visible : Visibility.Collapsed;
+        RecordingModeLabel = (_precisePlayTime
+            ? "PlayedTimePage_RecordingModePrecise"
+            : "PlayedTimePage_RecordingModeMinute").GetLocalized();
+    }
+
     private void UpdateWidth()
     {
-        double maxPlayTime = Game.PlayedTime.Count > 0 ? Game.PlayedTime.Values.Max() : 1;
-        foreach (PlayTimeViewModelItem item in Items)
+        long maxPlayTime = Items.Count > 0 ? Math.Max(1, Items.Max(item => item.TotalSeconds)) : 1;
+        foreach (PlayTimeDayViewModelItem item in Items)
             item.UpdateWidth(_totalWidth, maxPlayTime);
     }
 
     [RelayCommand]
-    private void Back()
+    private void Back() => _navigationService.GoBack();
+
+    [RelayCommand]
+    private void Refresh() => Update();
+
+    [RelayCommand]
+    private async Task ChangeTimeFormat()
     {
-        _navigationService.GoBack();
+        _timeAsHour = !_timeAsHour;
+        await _localSettingsService.SaveSettingAsync(KeyValues.TimeAsHour, _timeAsHour);
+        Game.RaisePropertyChanged(nameof(Game.TotalPlayTime));
+        Update();
+    }
+
+    [RelayCommand]
+    private async Task ToggleDateSort()
+    {
+        _dateDescending = !_dateDescending;
+        await _localSettingsService.SaveSettingAsync(KeyValues.PlayedTimeDateDescending, _dateDescending);
+        Update();
+    }
+
+    [RelayCommand]
+    private async Task ToggleRecordingMode()
+    {
+        bool nextMode = !_precisePlayTime;
+        PlayTimeMutationBackup? backup = nextMode ? PlayTimeMutationBackup.Create(Game) : null;
+        try
+        {
+            await _localSettingsService.SaveSettingAsync(KeyValues.PrecisePlayTime, nextMode);
+            _precisePlayTime = nextMode;
+            UpdateRecordingModeUi();
+            if (_precisePlayTime && PlayTimeSessionHelper.ReconcileCountedSessionTotals(Game))
+                await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup?.Restore(Game);
+            UpdateRecordingModeUi();
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    [RelayCommand]
+    private async Task AddSession()
+    {
+        if (!_precisePlayTime) return;
+        DateTime endedAt = DateTime.Now;
+        DateTime startedAt = endedAt.AddMinutes(-1);
+        EditPlayTimeSessionDialog dialog = new(
+            startedAt,
+            endedAt,
+            candidate => PlayTimeSessionHelper.HasOverlappingSession(Game, candidate));
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary || dialog.Result is not { } session) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            PlayTimeSessionHelper.AddSession(Game, session);
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
     }
 
     [RelayCommand]
     private async Task Edit()
     {
-        await new EditPlayTimeDialog(Game).ShowAsync();
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        ContentDialogResult result = await new EditPlayTimeDialog(Game, _precisePlayTime).ShowAsync();
+        if (result != ContentDialogResult.Primary) return;
+        try
+        {
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task EditSessionAsync(PlayTimeSession session)
+    {
+        if (session.IsOpen)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_OpenSessionCannotEdit".GetLocalized());
+            return;
+        }
+
+        EditPlayTimeSessionDialog dialog = new(
+            session,
+            candidate => PlayTimeSessionHelper.HasOverlappingSession(Game, candidate));
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary || dialog.Result is not { } replacement) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            PlayTimeSessionHelper.ReplaceSession(Game, session, replacement);
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task EditMinuteSessionAsync(MinutePlayTimeDaySegment segment)
+    {
+        if (segment.IsOpen)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_OpenSessionCannotEdit".GetLocalized());
+            return;
+        }
+
+        NumberBox minuteBox = new()
+        {
+            Value = segment.Minutes,
+            Minimum = 1,
+            Maximum = int.MaxValue,
+            SmallChange = 1,
+            LargeChange = 10,
+            SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline,
+            MinWidth = 150,
+        };
+        StackPanel content = new() { Spacing = 10 };
+        content.Children.Add(new TextBlock
+        {
+            Text = (segment.SpansMultipleDays
+                    ? "PlayedTimePage_EditCrossDayMinuteSessionDescription"
+                    : "PlayedTimePage_EditMinuteSessionDescription")
+                .GetLocalized(segment.Date.ToStringDefault()),
+            TextWrapping = TextWrapping.Wrap,
+        });
+        content.Children.Add(minuteBox);
+        ContentDialog dialog = new()
+        {
+            XamlRoot = App.MainWindow!.Content.XamlRoot,
+            RequestedTheme = App.MainWindow.Content is FrameworkElement element
+                ? element.RequestedTheme
+                : ElementTheme.Default,
+            Title = "PlayedTimePage_EditMinuteSessionTitle".GetLocalized(),
+            Content = content,
+            PrimaryButtonText = "Yes".GetLocalized(),
+            SecondaryButtonText = "PlayedTimePage_DeleteMinuteSessionButton".GetLocalized(),
+            CloseButtonText = "Cancel".GetLocalized(),
+            DefaultButton = ContentDialogButton.Primary,
+        };
+        ContentDialogResult dialogResult = await dialog.ShowAsync();
+        if (dialogResult == ContentDialogResult.Secondary)
+        {
+            await DeleteMinuteSessionAsync(segment);
+            return;
+        }
+        if (dialogResult != ContentDialogResult.Primary) return;
+
+        int minutes = double.IsNaN(minuteBox.Value)
+            ? segment.Minutes
+            : checked((int)Math.Min(int.MaxValue, Math.Max(1, minuteBox.Value)));
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            if (!PlayTimeSessionHelper.ReplaceMinuteSampleSegment(
+                    Game, segment.SessionId, segment.Date, minutes))
+            {
+                _infoService.Info(InfoBarSeverity.Warning,
+                    "PlayedTimePage_OpenSessionCannotEdit".GetLocalized());
+                return;
+            }
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task DeleteMinuteSessionAsync(MinutePlayTimeDaySegment segment)
+    {
+        if (segment.IsOpen)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_OpenSessionCannotEdit".GetLocalized());
+            return;
+        }
+
+        ContentDialog confirm = CreateConfirmationDialog(
+            "PlayedTimePage_DeleteMinuteSessionTitle".GetLocalized(),
+            (segment.SpansMultipleDays
+                    ? "PlayedTimePage_DeleteCrossDayMinuteSessionMessage"
+                    : "PlayedTimePage_DeleteMinuteSessionMessage")
+                .GetLocalized(
+                    segment.Date.ToStringDefault(),
+                    FormatMinuteSegmentDuration(segment.Minutes)));
+        if (await confirm.ShowAsync() != ContentDialogResult.Primary) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            if (!PlayTimeSessionHelper.ReplaceMinuteSampleSegment(
+                    Game, segment.SessionId, segment.Date, 0)) return;
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task CloseMinuteSessionAsync(MinutePlayTimeDaySegment segment)
+    {
+        RecordPlayTimeTask? activeTask = _bgTaskService.GetBgTask<RecordPlayTimeTask>(Game.Uuid.ToString("D"));
+        if (activeTask?.ActiveMinuteSessionId == segment.SessionId)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_ActiveSessionCannotClose".GetLocalized());
+            return;
+        }
+
+        ContentDialog confirm = CreateConfirmationDialog(
+            "PlayedTimePage_CloseSessionTitle".GetLocalized(),
+            "PlayedTimePage_CloseSessionMessage".GetLocalized(segment.EndedAt));
+        if (await confirm.ShowAsync() != ContentDialogResult.Primary) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            if (!PlayTimeSessionHelper.CloseOpenSession(Game, segment.SessionId)) return;
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task DeleteSessionAsync(PlayTimeSession session)
+    {
+        if (session.IsOpen)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_OpenSessionCannotEdit".GetLocalized());
+            return;
+        }
+
+        ContentDialog confirm = CreateConfirmationDialog(
+            "PlayedTimePage_DeleteSessionTitle".GetLocalized(),
+            "PlayedTimePage_DeleteSessionMessage".GetLocalized(
+                session.StartedAt,
+                session.EndedAt,
+                TimeToDisplayTimeConverter.ConvertSeconds(
+                    PlayTimeSessionHelper.GetSessionDurationSeconds(session), _timeAsHour)));
+        if (await confirm.ShowAsync() != ContentDialogResult.Primary) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            if (!PlayTimeSessionHelper.DeleteSession(Game, session.Id)) return;
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private async Task CloseSessionAsync(PlayTimeSession session)
+    {
+        RecordPlayTimeTask? activeTask = _bgTaskService.GetBgTask<RecordPlayTimeTask>(Game.Uuid.ToString("D"));
+        if (activeTask?.ActiveSessionId == session.Id)
+        {
+            _infoService.Info(InfoBarSeverity.Warning, "PlayedTimePage_ActiveSessionCannotClose".GetLocalized());
+            return;
+        }
+
+        ContentDialog confirm = CreateConfirmationDialog(
+            "PlayedTimePage_CloseSessionTitle".GetLocalized(),
+            "PlayedTimePage_CloseSessionMessage".GetLocalized(session.EndedAt));
+        if (await confirm.ShowAsync() != ContentDialogResult.Primary) return;
+
+        PlayTimeMutationBackup backup = PlayTimeMutationBackup.Create(Game);
+        try
+        {
+            if (!PlayTimeSessionHelper.CloseOpenSession(Game, session.Id)) return;
+            await SaveAndSyncAsync();
+            Update();
+        }
+        catch (Exception ex)
+        {
+            backup.Restore(Game);
+            _infoService.Info(InfoBarSeverity.Error,
+                "PlayedTimePage_SaveFailed".GetLocalized(), ex.GetBaseException().Message);
+        }
+    }
+
+    private ContentDialog CreateConfirmationDialog(string title, string message) => new()
+    {
+        XamlRoot = App.MainWindow!.Content.XamlRoot,
+        RequestedTheme = App.MainWindow.Content is FrameworkElement element
+            ? element.RequestedTheme
+            : ElementTheme.Default,
+        Title = title,
+        Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+        PrimaryButtonText = "Yes".GetLocalized(),
+        CloseButtonText = "Cancel".GetLocalized(),
+        DefaultButton = ContentDialogButton.Close,
+    };
+
+    private async Task SaveAndSyncAsync()
+    {
+        PlayTimeSessionHelper.RefreshDerivedState(Game);
         await _galgameCollectionService.SaveGalgameAsync(Game);
-        Update();
-        Game.LastPlayTime = Game.PlayedTime.Count > 0
-            ? Game.PlayedTime.Keys.Select(Utils.TryParseDateGuessCulture).Max()
-            : DateTime.MinValue;
+        Game.RaisePropertyChanged(nameof(Game.TotalPlayTime));
+        Game.RaisePropertyChanged(nameof(Game.LastPlayTime));
         _pvnService.Upload(Game, PvnUploadProperties.PlayTime);
+    }
+
+    private sealed class PlayTimeMutationBackup
+    {
+        private Dictionary<string, int> PlayedTime { get; init; } = [];
+        private Dictionary<string, long> PlayedTimeSeconds { get; init; } = [];
+        private List<PlayTimeSession> Sessions { get; init; } = [];
+        private int TotalPlayTime { get; init; }
+        private DateTime LastPlayTime { get; init; }
+        private int PlayCount { get; init; }
+
+        internal static PlayTimeMutationBackup Create(Galgame game) => new()
+        {
+            PlayedTime = new Dictionary<string, int>(game.PlayedTime),
+            PlayedTimeSeconds = new Dictionary<string, long>(game.PlayedTimeSeconds),
+            Sessions = game.PlayTimeSessions.Select(session => session.Clone()).ToList(),
+            TotalPlayTime = game.TotalPlayTime,
+            LastPlayTime = game.LastPlayTime,
+            PlayCount = game.PlayCount,
+        };
+
+        internal void Restore(Galgame game)
+        {
+            game.PlayedTime = new Dictionary<string, int>(PlayedTime);
+            game.PlayedTimeSeconds = new Dictionary<string, long>(PlayedTimeSeconds);
+            game.PlayTimeSessions = Sessions.Select(session => session.Clone()).ToList();
+            game.TotalPlayTime = TotalPlayTime;
+            game.LastPlayTime = LastPlayTime;
+            game.PlayCount = PlayCount;
+        }
     }
 }
 
-public partial class PlayTimeViewModelItem : ObservableObject
+public partial class PlayTimeDayViewModelItem : ObservableObject
 {
     [ObservableProperty] private double _width;
-    [ObservableProperty] private int _playTime;
-    [ObservableProperty] private string _date;
+    public DateTime DateValue { get; }
+    [ObservableProperty] private string _date = string.Empty;
+    [ObservableProperty] private long _totalSeconds;
+    [ObservableProperty] private long _legacySeconds;
+    [ObservableProperty] private string _totalText = string.Empty;
+    [ObservableProperty] private string _legacyText = string.Empty;
+    public ObservableCollection<PlayTimeBarSegmentViewModelItem> Segments { get; }
+    public ObservableCollection<PlayTimeSessionViewModelItem> Sessions { get; }
+    [ObservableProperty] private bool _isExpanded;
+    [ObservableProperty] private Visibility _preciseVisibility;
+    [ObservableProperty] private Visibility _minuteVisibility;
 
-    public PlayTimeViewModelItem(string date, int playTime)
+    public PlayTimeDayViewModelItem(
+        DateTime date,
+        long totalSeconds,
+        long legacySeconds,
+        IEnumerable<PlayTimeBarSegmentViewModelItem> segments,
+        IEnumerable<PlayTimeSessionViewModelItem> sessions,
+        bool precise,
+        bool showSecondPrecision,
+        bool timeAsHour,
+        bool isExpanded = false)
     {
-        _date = date;
-        _playTime = playTime;
+        DateValue = date;
+        Date = precise ? date.ToString("yyyy/M/d dddd") : date.ToString("yyyy/M/d");
+        TotalSeconds = Math.Max(0, totalSeconds);
+        LegacySeconds = Math.Max(0, legacySeconds);
+        TotalText = precise && showSecondPrecision
+            ? TimeToDisplayTimeConverter.ConvertSeconds(TotalSeconds, timeAsHour)
+            : precise
+                ? TimeToDisplayTimeConverter.ConvertWholeMinutesWithUnits(TotalSeconds / 60, timeAsHour)
+                : TimeToDisplayTimeConverter.ConvertMinuteModeSeconds(TotalSeconds, timeAsHour);
+        LegacyText = LegacySeconds > 0
+            ? "PlayedTimePage_LegacySummary".GetLocalized(
+                TimeToDisplayTimeConverter.ConvertWholeMinuteSecondsWithUnits(LegacySeconds, timeAsHour))
+            : string.Empty;
+        Segments = new ObservableCollection<PlayTimeBarSegmentViewModelItem>(segments);
+        Sessions = new ObservableCollection<PlayTimeSessionViewModelItem>(sessions);
+        PreciseVisibility = precise ? Visibility.Visible : Visibility.Collapsed;
+        MinuteVisibility = precise ? Visibility.Collapsed : Visibility.Visible;
+        // 首次进入页面时日期默认折叠；刷新或重建列表时可恢复用户当前展开的日期。
+        IsExpanded = isExpanded;
     }
 
-    public void UpdateWidth(double totalWidth, double maxPlayTime)
+    public void ApplySnapshot(PlayTimeDayViewModelItem source)
     {
-        Width = Math.Max(totalWidth - 200, 0); //预留日期、时间显示区域
-        Width = Width * PlayTime / maxPlayTime;
+        Date = source.Date;
+        TotalSeconds = source.TotalSeconds;
+        LegacySeconds = source.LegacySeconds;
+        TotalText = source.TotalText;
+        LegacyText = source.LegacyText;
+        PreciseVisibility = source.PreciseVisibility;
+        MinuteVisibility = source.MinuteVisibility;
+
+        Segments.Clear();
+        foreach (PlayTimeBarSegmentViewModelItem segment in source.Segments) Segments.Add(segment);
+        SynchronizeSessions(source.Sessions);
+    }
+
+    private void SynchronizeSessions(IReadOnlyList<PlayTimeSessionViewModelItem> updatedSessions)
+    {
+        for (int targetIndex = 0; targetIndex < updatedSessions.Count; targetIndex++)
+        {
+            PlayTimeSessionViewModelItem updated = updatedSessions[targetIndex];
+            int existingIndex = -1;
+            for (int index = targetIndex; index < Sessions.Count; index++)
+            {
+                if (Sessions[index].SessionId != updated.SessionId ||
+                    Sessions[index].DateValue != updated.DateValue) continue;
+                existingIndex = index;
+                break;
+            }
+
+            if (existingIndex < 0)
+            {
+                Sessions.Insert(targetIndex, updated);
+                continue;
+            }
+
+            if (existingIndex != targetIndex) Sessions.Move(existingIndex, targetIndex);
+            PlayTimeSessionViewModelItem existing = Sessions[targetIndex];
+            if (ReferenceEquals(existing.SourceSession, updated.SourceSession))
+                existing.ApplySnapshot(updated);
+            else
+            {
+                updated.IsExpanded = existing.IsExpanded;
+                Sessions[targetIndex] = updated;
+            }
+        }
+
+        while (Sessions.Count > updatedSessions.Count) Sessions.RemoveAt(Sessions.Count - 1);
+    }
+
+    public void UpdateWidth(double totalWidth, long maxPlayTime)
+    {
+        double reservedWidth = PreciseVisibility == Visibility.Visible ? 260 : 200;
+        Width = Math.Max(totalWidth - reservedWidth, 0) * TotalSeconds / Math.Max(1, maxPlayTime);
+        long segmentTotal = Math.Max(1, Segments.Aggregate(0L, (total, segment) =>
+            total > long.MaxValue - segment.DurationSeconds
+                ? long.MaxValue
+                : total + segment.DurationSeconds));
+        foreach (PlayTimeBarSegmentViewModelItem segment in Segments)
+            segment.Width = Math.Max(2, Width * segment.DurationSeconds / segmentTotal);
+    }
+}
+
+public partial class PlayTimeBarSegmentViewModelItem(
+    long durationSeconds,
+    double opacity,
+    string toolTip = "",
+    Func<Task>? activate = null) : ObservableObject
+{
+    public long DurationSeconds { get; } = Math.Max(0, durationSeconds);
+    public double Opacity { get; } = opacity;
+    public string ToolTip { get; } = toolTip;
+    public Visibility InteractiveVisibility { get; } = activate is null
+        ? Visibility.Collapsed
+        : Visibility.Visible;
+    public IAsyncRelayCommand ActivateCommand { get; } = new AsyncRelayCommand(
+        activate ?? (() => Task.CompletedTask));
+    [ObservableProperty] private double _width;
+}
+
+public partial class PlayTimeSessionViewModelItem : ObservableObject
+{
+    public Guid SessionId { get; }
+    public DateTime DateValue { get; }
+    internal PlayTimeSession SourceSession { get; }
+    [ObservableProperty] private string _timeRange = string.Empty;
+    [ObservableProperty] private string _duration = string.Empty;
+    [ObservableProperty] private string _kind = string.Empty;
+    [ObservableProperty] private Visibility _editVisibility;
+    [ObservableProperty] private Visibility _deleteVisibility;
+    [ObservableProperty] private Visibility _closeVisibility;
+    [ObservableProperty] private Visibility _emptyActivityVisibility;
+    public ObservableCollection<PlayTimeActivityViewModelItem> ActivityIntervals { get; }
+    public IAsyncRelayCommand EditCommand { get; }
+    public IAsyncRelayCommand DeleteCommand { get; }
+    public IAsyncRelayCommand CloseCommand { get; }
+    [ObservableProperty] private bool _isExpanded;
+
+    public PlayTimeSessionViewModelItem(
+        PlayTimeSession session,
+        PlayTimeDaySegment segment,
+        Func<PlayTimeSession, Task> edit,
+        Func<PlayTimeSession, Task> delete,
+        Func<PlayTimeSession, Task> close,
+        bool timeAsHour,
+        bool isExpanded = false)
+    {
+        SessionId = segment.SessionId;
+        DateValue = segment.Date;
+        SourceSession = session;
+        TimeRange = $"{FormatBoundary(segment.StartedAt, segment.Date, false)}–" +
+                    $"{FormatBoundary(segment.EndedAt, segment.Date, true)}";
+        Duration = TimeToDisplayTimeConverter.ConvertSeconds(segment.DurationSeconds, timeAsHour);
+        Kind = session.IsOpen
+            ? "PlayedTimePage_SessionOpen".GetLocalized()
+            : session.Kind == PlayTimeSessionKind.Imported
+                ? "PlayedTimePage_SessionImported".GetLocalized()
+                : session.Kind == PlayTimeSessionKind.Manual
+                    ? "PlayedTimePage_SessionManual".GetLocalized()
+                    : "PlayedTimePage_SessionNative".GetLocalized();
+        EditVisibility = session.IsOpen ? Visibility.Collapsed : Visibility.Visible;
+        DeleteVisibility = EditVisibility;
+        CloseVisibility = session.IsOpen ? Visibility.Visible : Visibility.Collapsed;
+        ActivityIntervals = new ObservableCollection<PlayTimeActivityViewModelItem>(
+            PlayTimeSessionHelper.GetActivityIntervalsForDay(session, segment.Date)
+                .Select(interval => new PlayTimeActivityViewModelItem(interval, segment.Date, timeAsHour)));
+        EmptyActivityVisibility = ActivityIntervals.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        EditCommand = new AsyncRelayCommand(() => edit(session));
+        DeleteCommand = new AsyncRelayCommand(() => delete(session));
+        CloseCommand = new AsyncRelayCommand(() => close(session));
+        IsExpanded = isExpanded;
+    }
+
+    public void ApplySnapshot(PlayTimeSessionViewModelItem source)
+    {
+        TimeRange = source.TimeRange;
+        Duration = source.Duration;
+        Kind = source.Kind;
+        EditVisibility = source.EditVisibility;
+        DeleteVisibility = source.DeleteVisibility;
+        CloseVisibility = source.CloseVisibility;
+        EmptyActivityVisibility = source.EmptyActivityVisibility;
+        ActivityIntervals.Clear();
+        foreach (PlayTimeActivityViewModelItem interval in source.ActivityIntervals)
+            ActivityIntervals.Add(interval);
+    }
+
+    internal static string FormatBoundary(DateTime value, DateTime date, bool isEnd) =>
+        isEnd && value == date.AddDays(1) ? "24:00:00" : value.ToString("HH:mm:ss");
+}
+
+public sealed class PlayTimeActivityViewModelItem
+{
+    public string TimeRange { get; }
+    public string Duration { get; }
+
+    public PlayTimeActivityViewModelItem(
+        PlayTimeActivityInterval interval,
+        DateTime date,
+        bool timeAsHour)
+    {
+        TimeRange = $"{PlayTimeSessionViewModelItem.FormatBoundary(interval.StartedAt, date, false)}–" +
+                    $"{PlayTimeSessionViewModelItem.FormatBoundary(interval.EndedAt, date, true)}";
+        long seconds = Math.Max(0, (long)Math.Round(
+            (interval.EndedAt - interval.StartedAt).TotalSeconds,
+            MidpointRounding.AwayFromZero));
+        Duration = TimeToDisplayTimeConverter.ConvertSeconds(seconds, timeAsHour);
     }
 }

--- a/GalgameManager/ViewModels/PlayedTimeViewModel.cs
+++ b/GalgameManager/ViewModels/PlayedTimeViewModel.cs
@@ -734,7 +734,7 @@ public partial class PlayTimeDayViewModelItem : ObservableObject
         TotalText = precise && showSecondPrecision
             ? TimeToDisplayTimeConverter.ConvertSeconds(TotalSeconds, timeAsHour)
             : precise
-                ? TimeToDisplayTimeConverter.ConvertWholeMinutesWithUnits(TotalSeconds / 60, timeAsHour)
+                ? TimeToDisplayTimeConverter.ConvertWholeMinuteSecondsWithUnits(TotalSeconds, timeAsHour)
                 : TimeToDisplayTimeConverter.ConvertMinuteModeSeconds(TotalSeconds, timeAsHour);
         LegacyText = LegacySeconds > 0
             ? "PlayedTimePage_LegacySummary".GetLocalized(

--- a/GalgameManager/ViewModels/SettingsViewModel.cs
+++ b/GalgameManager/ViewModels/SettingsViewModel.cs
@@ -88,6 +88,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
         // 设置页会被 Frame 缓存；外部入口（例如单游戏按键映射对话框）修改总开关后，
         // 每次返回设置页都重新读取，避免界面状态与真实启动配置不一致。
         GameReMapEnabled = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.GameReMapEnabled);
+        PrecisePlayTime = await _localSettingsService.ReadSettingAsync<bool>(KeyValues.PrecisePlayTime);
         try
         {
             await _updateService.UpdateSettingsBadgeAsync(); //通过这句话来触发更新弹窗提醒（如果这个版本没触发过的话）
@@ -138,6 +139,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
 
         //GAME
         _recordOnlyForeground = _localSettingsService.ReadSettingAsync<bool>(KeyValues.RecordOnlyWhenForeground).Result;
+        _precisePlayTime = _localSettingsService.ReadSettingAsync<bool>(KeyValues.PrecisePlayTime).Result;
         _playingWindowMode = _localSettingsService.ReadSettingAsync<WindowMode>(KeyValues.PlayingWindowMode).Result;
         _minPlayTimeRecordThreshold = _localSettingsService.ReadSettingAsync<int>(KeyValues.MinPlayTimeRecordThreshold).Result;
         LocalEmulatorPath = _localSettingsService.ReadSettingAsync<string>(KeyValues.LocaleEmulatorPath).Result;
@@ -453,6 +455,7 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     #region GAME
 
     [ObservableProperty] private bool _recordOnlyForeground;
+    [ObservableProperty] private bool _precisePlayTime;
     [ObservableProperty] private WindowMode _playingWindowMode;
     [ObservableProperty] private int _minPlayTimeRecordThreshold;
     [ObservableProperty] private string? _localEmulatorPath;
@@ -469,6 +472,8 @@ public partial class SettingsViewModel : ObservableObject, INavigationAware
     public WindowMode[] PlayingWindowModes;
 
     partial void OnRecordOnlyForegroundChanged(bool value) => _localSettingsService.SaveSettingAsync(KeyValues.RecordOnlyWhenForeground, value);
+
+    partial void OnPrecisePlayTimeChanged(bool value) => _localSettingsService.SaveSettingAsync(KeyValues.PrecisePlayTime, value);
 
     partial void OnPlayingWindowModeChanged(WindowMode value) => _localSettingsService.SaveSettingAsync(KeyValues.PlayingWindowMode, value);
 

--- a/GalgameManager/Views/Dialog/EditPlayTimeDialog.xaml
+++ b/GalgameManager/Views/Dialog/EditPlayTimeDialog.xaml
@@ -9,33 +9,88 @@
     mc:Ignorable="d"
     Style="{ThemeResource DefaultContentDialogStyle}">
 
-    <Grid MaxHeight="300">
+    <Grid MaxHeight="{x:Bind DialogMaxHeight}" MinWidth="{x:Bind DialogMinWidth}"
+          Background="Transparent"
+          PointerPressed="DialogContentRoot_OnPointerPressed">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        
-        <ListView Grid.Row="0" x:Name="ListView">
+
+        <TextBlock x:Name="DescriptionText" Grid.Row="0" x:Uid="EditPlayTimeDialog_Description"
+                   Margin="12,0,12,10" TextWrapping="Wrap"
+                   Visibility="{x:Bind PreciseVisibility}"
+                   Style="{ThemeResource DescriptionTextStyle}"/>
+
+        <Grid Grid.Row="1" ColumnSpacing="8" Margin="12,0,12,4"
+              Visibility="{x:Bind PreciseVisibility}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="140"/>
+                <ColumnDefinition Width="104"/>
+                <ColumnDefinition Width="104"/>
+                <ColumnDefinition Width="104"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Uid="EditPlayTimeDialog_DateColumn"/>
+            <TextBlock Grid.Column="1" x:Uid="EditPlayTimeDialog_HourColumn"/>
+            <TextBlock Grid.Column="2" x:Uid="EditPlayTimeDialog_MinuteColumn"/>
+            <TextBlock Grid.Column="3" x:Uid="EditPlayTimeDialog_SecondColumn"
+                       Visibility="{x:Bind SecondsVisibility}"/>
+        </Grid>
+
+        <ListView Grid.Row="2" x:Name="PreciseListView"
+                  Visibility="{x:Bind PreciseVisibility}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local:DisplayPlayTime">
+                    <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="140"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="104"/>
+                            <ColumnDefinition Width="104"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{x:Bind Date}" VerticalAlignment="Center"/>
+                        <NumberBox Grid.Column="1" Width="104" Value="{x:Bind Hours, Mode=TwoWay}"
+                                   Minimum="0" SpinButtonPlacementMode="Compact"/>
+                        <NumberBox Grid.Column="2" Width="104" Value="{x:Bind Minutes, Mode=TwoWay}"
+                                   Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                        <NumberBox Grid.Column="3" Width="104" Value="{x:Bind Seconds, Mode=TwoWay}"
+                                   Visibility="{x:Bind SecondsVisibility}"
+                                   Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <ListView Grid.Row="2" x:Name="MinuteListView"
+                  Visibility="{x:Bind MinuteVisibility}">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local:DisplayPlayTime">
                     <StackPanel Orientation="Horizontal" Spacing="20">
                         <TextBlock Text="{x:Bind Date}" VerticalAlignment="Center" MinWidth="100"/>
-                        <NumberBox Value="{x:Bind PlayedTime, Mode=TwoWay}" 
-                                   VerticalAlignment="Center" Margin="0 5 0 5" MinWidth="70"
+                        <NumberBox Value="{x:Bind PlayedTime, Mode=TwoWay}"
+                                   VerticalAlignment="Center" Margin="0,5,0,5" MinWidth="70"
                                    SpinButtonPlacementMode="Inline" SmallChange="1" LargeChange="10"/>
                     </StackPanel>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="10" Margin="0 10 0 0">
+        <TextBlock x:Name="ValidationMessage" Grid.Row="3"
+                   Margin="0,8,0,0"
+                   Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                   TextWrapping="Wrap" Visibility="Collapsed"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Spacing="10" Margin="0 10 0 0">
             <TextBlock x:Uid="EditPlayTimeDialog_PlayCountLabel" VerticalAlignment="Center"/>
             <NumberBox x:Name="PlayCountNumberBox" MinWidth="100" ValueChanged="PlayCountNumberBox_OnValueChanged"
                        SpinButtonPlacementMode="Inline" SmallChange="1" LargeChange="1"/>
         </StackPanel>
         
-        <Grid Grid.Row="2" Margin="0 5 0 -15">
+        <Grid Grid.Row="5" Margin="0,8,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>

--- a/GalgameManager/Views/Dialog/EditPlayTimeDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/EditPlayTimeDialog.xaml.cs
@@ -1,8 +1,12 @@
 using System.Collections.ObjectModel;
+using GalgameManager.Core.Helpers;
 using GalgameManager.Helpers;
+using GalgameManager.Helpers.Converter;
 using GalgameManager.Models;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 
 namespace GalgameManager.Views.Dialog;
 
@@ -10,10 +14,25 @@ public sealed partial class EditPlayTimeDialog : ContentDialog
 {
     private readonly ObservableCollection<DisplayPlayTime> _playTimes = new();
     private readonly Galgame _galgame;
+    private readonly Dictionary<DateTime, long> _sessionMinimumSeconds;
+    private readonly HashSet<DateTime> _originalEditableDates = [];
+    private readonly bool _preciseMode;
+    private int _playCount;
+    public Visibility SecondsVisibility { get; }
+    public Visibility PreciseVisibility { get; }
+    public Visibility MinuteVisibility { get; }
+    public double DialogMinWidth { get; }
+    public double DialogMaxHeight { get; }
 
-    public EditPlayTimeDialog(Galgame galgame)
+    public EditPlayTimeDialog(Galgame galgame, bool preciseMode = true)
     {
-        _galgame = galgame; // Store the galgame object
+        _galgame = galgame;
+        _preciseMode = preciseMode;
+        SecondsVisibility = preciseMode ? Visibility.Visible : Visibility.Collapsed;
+        PreciseVisibility = preciseMode ? Visibility.Visible : Visibility.Collapsed;
+        MinuteVisibility = preciseMode ? Visibility.Collapsed : Visibility.Visible;
+        DialogMinWidth = preciseMode ? 500 : 0;
+        DialogMaxHeight = preciseMode ? 420 : 300;
         InitializeComponent();
         RequestedTheme = App.MainWindow?.Content is Microsoft.UI.Xaml.FrameworkElement element ? element.RequestedTheme : RequestedTheme;
 
@@ -21,58 +40,130 @@ public sealed partial class EditPlayTimeDialog : ContentDialog
         Title = "EditPlayTimeDialog_Title".GetLocalized();
         PrimaryButtonText = "Yes".GetLocalized();
         SecondaryButtonText = "Cancel".GetLocalized();
+        DescriptionText.Text = (preciseMode
+            ? "EditPlayTimeDialog_PreciseDescription"
+            : "EditPlayTimeDialog_MinuteDescription").GetLocalized();
 
-        PlayCountNumberBox.Value = _galgame.PlayCount; // Initialize NumberBox
+        _playCount = _galgame.PlayCount;
+        PlayCountNumberBox.Value = _playCount;
+        Dictionary<DateTime, long> preciseSessionMinimumSeconds = _galgame.PlayTimeSessions
+            .Where(session => session.CountsTowardPlayTime)
+            .SelectMany(PlayTimeSessionHelper.SplitSessionByDay)
+            .GroupBy(segment => segment.Date)
+            .ToDictionary(group => group.Key, group => group.Aggregate(0L, (total, segment) =>
+                total > long.MaxValue - segment.DurationSeconds
+                    ? long.MaxValue
+                    : total + segment.DurationSeconds));
 
-        foreach (var (date, playedTime) in _galgame.PlayedTime)
+        IEnumerable<string> dateKeys = preciseMode
+            ? _galgame.PlayedTime.Keys.Concat(_galgame.PlayedTimeSeconds.Keys)
+            : _galgame.PlayedTime.Keys;
+        HashSet<DateTime> dates = dateKeys
+            .Select(Utils.TryParseDateGuessCulture)
+            .Where(date => date.Year > 1900)
+            .Select(date => date.Date)
+            .ToHashSet();
+        foreach (DateTime date in preciseSessionMinimumSeconds.Keys) dates.Add(date);
+        foreach (PlayTimeSession session in _galgame.PlayTimeSessions
+                     .Where(session => session.Kind == PlayTimeSessionKind.MinuteSampled))
         {
-            DisplayPlayTime displayPlayTime = new()
+            if (session.SampledMinutesByDay is null) continue;
+            foreach (string key in session.SampledMinutesByDay.Keys)
             {
-                Date = date,
-                PlayedTime = playedTime
-            };
-            _playTimes.Add(displayPlayTime);
-        }
-        ListView.ItemsSource = _playTimes;
-
-        PrimaryButtonClick += (_, _) =>
-        {
-            // PlayCount is already updated by PlayCountNumberBox_OnValueChanged
-            _galgame.PlayedTime.Clear();
-            var totalTime = 0;
-            
-            foreach (DisplayPlayTime time in _playTimes)
-            {
-                if (time.PlayedTime > 0)
-                {
-                    _galgame.PlayedTime.Add(time.Date, time.PlayedTime);
-                    totalTime += time.PlayedTime;
-                }
+                DateTime date = Utils.TryParseDateGuessCulture(key);
+                if (date.Year > 1900) dates.Add(date.Date);
             }
-            
-            _galgame.TotalPlayTime = totalTime;
-            
-            // LastPlayTime 现在是自动计算的，不需要手动设置
-        };
+        }
+
+        _sessionMinimumSeconds = dates.ToDictionary(
+            date => date,
+            date =>
+            {
+                preciseSessionMinimumSeconds.TryGetValue(date, out long preciseMinimum);
+                long minuteMinimum = PlayTimeSessionHelper.GetMinuteSampleSecondsForDay(_galgame, date);
+                return preciseMinimum > long.MaxValue - minuteMinimum
+                    ? long.MaxValue
+                    : preciseMinimum + minuteMinimum;
+            });
+        _originalEditableDates.UnionWith(dates);
+
+        foreach (DateTime date in dates.OrderBy(date => date))
+        {
+            _sessionMinimumSeconds.TryGetValue(date, out long minimumSeconds);
+            _playTimes.Add(new DisplayPlayTime(
+                date.ToStringDefault(),
+                PlayTimeSessionHelper.GetDaySeconds(_galgame, date),
+                minimumSeconds,
+                _preciseMode));
+        }
+        PreciseListView.ItemsSource = _playTimes;
+        MinuteListView.ItemsSource = _playTimes;
+
+        PrimaryButtonClick += ValidateAndApply;
+    }
+
+    private void ValidateAndApply(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        DisplayPlayTime? invalid = _playTimes.FirstOrDefault(time => time.TotalSeconds < time.MinimumSeconds);
+        if (invalid is not null)
+        {
+            ValidationMessage.Text = "EditPlayTimeDialog_SessionMinimum".GetLocalized(
+                invalid.Date,
+                TimeToDisplayTimeConverter.ConvertSeconds(invalid.MinimumSeconds));
+            ValidationMessage.Visibility = Visibility.Visible;
+            args.Cancel = true;
+            return;
+        }
+
+        _galgame.PlayedTime = [];
+        HashSet<DateTime> retainedDates = _playTimes
+            .Select(time => Utils.TryParseDateGuessCulture(time.Date).Date)
+            .ToHashSet();
+
+        if (_preciseMode)
+        {
+            _galgame.PlayedTimeSeconds = [];
+        }
+        else
+        {
+            foreach (DateTime removedDate in _originalEditableDates.Except(retainedDates))
+                RemoveSecondBuckets(removedDate);
+        }
+        _galgame.PlayCount = _playCount;
+        foreach (DisplayPlayTime time in _playTimes)
+        {
+            long seconds = time.TotalSeconds;
+            DateTime date = Utils.TryParseDateGuessCulture(time.Date).Date;
+            RemoveSecondBuckets(date);
+            if (seconds <= 0) continue;
+            _galgame.PlayedTimeSeconds[date.ToStringDefault()] = seconds;
+        }
+        PlayTimeSessionHelper.RefreshDerivedState(_galgame);
+    }
+
+    private void RemoveSecondBuckets(DateTime date)
+    {
+        string[] keys = _galgame.PlayedTimeSeconds.Keys
+            .Where(key => Utils.TryParseDateGuessCulture(key).Date == date.Date)
+            .ToArray();
+        foreach (string key in keys) _galgame.PlayedTimeSeconds.Remove(key);
     }
 
     private void PlayCountNumberBox_OnValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
     {
-        if (_galgame != null)
-        {
-            // Ensure the value is not NaN, which can happen if the box is cleared. Default to 0.
-            _galgame.PlayCount = (int)(double.IsNaN(args.NewValue) ? 0 : args.NewValue);
-        }
+        _playCount = (int)(double.IsNaN(args.NewValue) ? 0 : args.NewValue);
     }
 
     private void DatePickerFlyout_OnDatePicked(DatePickerFlyout sender, DatePickedEventArgs args)
     {
-        if (_playTimes.Any(time => time.Date == sender.Date.ToString("yyyy/M/d"))) return;
-        DisplayPlayTime newTime = new()
-        {
-            Date = sender.Date.ToString("yyyy/M/d"),
-            PlayedTime = 0
-        };
+        DateTime selectedDate = sender.Date.Date;
+        if (_playTimes.Any(time => Utils.TryParseDateGuessCulture(time.Date).Date == selectedDate)) return;
+        _sessionMinimumSeconds.TryGetValue(selectedDate, out long minimumSeconds);
+        DisplayPlayTime newTime = new(
+            selectedDate.ToStringDefault(),
+            PlayTimeSessionHelper.GetDaySeconds(_galgame, selectedDate),
+            minimumSeconds,
+            _preciseMode);
         foreach (DisplayPlayTime time in _playTimes)
             if (newTime < time)
             {
@@ -84,15 +175,68 @@ public sealed partial class EditPlayTimeDialog : ContentDialog
 
     private void ButtonDelete_OnClick(object sender, RoutedEventArgs e)
     {
-        if (ListView.SelectedItem is not DisplayPlayTime time) return;
+        object? selectedItem = _preciseMode
+            ? PreciseListView.SelectedItem
+            : MinuteListView.SelectedItem;
+        if (selectedItem is not DisplayPlayTime time) return;
+        if (time.MinimumSeconds > 0)
+        {
+            ValidationMessage.Text = "EditPlayTimeDialog_SessionDateCannotDelete".GetLocalized(time.Date);
+            ValidationMessage.Visibility = Visibility.Visible;
+            return;
+        }
         _playTimes.Remove(time);
+    }
+
+    private void DialogContentRoot_OnPointerPressed(object sender, PointerRoutedEventArgs args)
+    {
+        if (args.OriginalSource is not DependencyObject source) return;
+        for (DependencyObject? current = source;
+             current is not null && !ReferenceEquals(current, sender);
+             current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is Microsoft.UI.Xaml.Controls.Control) return;
+        }
+        Focus(FocusState.Programmatic);
     }
 }
 
 public class DisplayPlayTime
 {
-    public string Date = string.Empty;
-    public int PlayedTime;
+    public string Date { get; }
+    public double PlayedTime { get; set; }
+    public double Hours { get; set; }
+    public double Minutes { get; set; }
+    public double Seconds { get; set; }
+    public Visibility SecondsVisibility { get; }
+    public long MinimumSeconds { get; }
+    private readonly bool _preciseMode;
+    private readonly long _preservedSeconds;
+    public long TotalSeconds => _preciseMode
+        ? ReadPart(Hours, long.MaxValue / 3600) * 3600L +
+          ReadPart(Minutes, 59) * 60L +
+          ReadPart(Seconds, 59)
+        : ReadPart(PlayedTime, int.MaxValue) * 60L + _preservedSeconds;
+
+    public DisplayPlayTime(string date, long totalSeconds, long minimumSeconds, bool preciseMode = true)
+    {
+        Date = date;
+        _preciseMode = preciseMode;
+        long normalized = Math.Max(0, totalSeconds);
+        PlayedTime = normalized / 60;
+        Hours = normalized / 3600;
+        Minutes = normalized % 3600 / 60;
+        _preservedSeconds = normalized % 60;
+        Seconds = preciseMode ? _preservedSeconds : 0;
+        SecondsVisibility = preciseMode ? Visibility.Visible : Visibility.Collapsed;
+        MinimumSeconds = Math.Max(0, minimumSeconds);
+    }
+
+    private static long ReadPart(double value, long maximum)
+    {
+        if (double.IsNaN(value) || value <= 0) return 0;
+        return Math.Min((long)value, maximum);
+    }
 
     public static bool operator < (DisplayPlayTime x, DisplayPlayTime y)
     {

--- a/GalgameManager/Views/Dialog/EditPlayTimeSessionDialog.xaml
+++ b/GalgameManager/Views/Dialog/EditPlayTimeSessionDialog.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentDialog
+    x:Class="GalgameManager.Views.Dialog.EditPlayTimeSessionDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Style="{ThemeResource DefaultContentDialogStyle}">
+
+    <StackPanel Spacing="12" MinWidth="500"
+                Background="Transparent"
+                PointerPressed="DialogContentRoot_OnPointerPressed">
+        <TextBlock x:Uid="EditPlayTimeSessionDialog_Description"
+                   TextWrapping="Wrap"
+                   Style="{ThemeResource DescriptionTextStyle}"/>
+
+        <Grid ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="160"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <CalendarDatePicker x:Name="StartDatePicker"
+                                x:Uid="EditPlayTimeSessionDialog_StartDate"/>
+            <StackPanel Grid.Column="1" Spacing="4">
+                <TextBlock x:Uid="EditPlayTimeSessionDialog_StartTime"/>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <NumberBox x:Name="StartHourBox" x:Uid="EditPlayTimeSessionDialog_Hour"
+                               Width="96" Minimum="0" Maximum="23" SpinButtonPlacementMode="Compact"/>
+                    <NumberBox x:Name="StartMinuteBox" x:Uid="EditPlayTimeSessionDialog_Minute"
+                               Width="96" Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                    <NumberBox x:Name="StartSecondBox" x:Uid="EditPlayTimeSessionDialog_Second"
+                               Width="96" Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+
+        <Grid ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="160"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <CalendarDatePicker x:Name="EndDatePicker"
+                                x:Uid="EditPlayTimeSessionDialog_EndDate"/>
+            <StackPanel Grid.Column="1" Spacing="4">
+                <TextBlock x:Uid="EditPlayTimeSessionDialog_EndTime"/>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <NumberBox x:Name="EndHourBox" x:Uid="EditPlayTimeSessionDialog_Hour"
+                               Width="96" Minimum="0" Maximum="23" SpinButtonPlacementMode="Compact"/>
+                    <NumberBox x:Name="EndMinuteBox" x:Uid="EditPlayTimeSessionDialog_Minute"
+                               Width="96" Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                    <NumberBox x:Name="EndSecondBox" x:Uid="EditPlayTimeSessionDialog_Second"
+                               Width="96" Minimum="0" Maximum="59" SpinButtonPlacementMode="Compact"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+
+        <TextBlock x:Name="ValidationMessage"
+                   Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                   TextWrapping="Wrap"
+                   Visibility="Collapsed"/>
+    </StackPanel>
+</ContentDialog>

--- a/GalgameManager/Views/Dialog/EditPlayTimeSessionDialog.xaml.cs
+++ b/GalgameManager/Views/Dialog/EditPlayTimeSessionDialog.xaml.cs
@@ -1,0 +1,142 @@
+using GalgameManager.Helpers;
+using GalgameManager.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+
+namespace GalgameManager.Views.Dialog;
+
+public sealed partial class EditPlayTimeSessionDialog : ContentDialog
+{
+    private readonly PlayTimeSession _original;
+    private readonly Func<PlayTimeSession, bool>? _overlapsExistingSession;
+    public PlayTimeSession? Result { get; private set; }
+
+    public EditPlayTimeSessionDialog(
+        PlayTimeSession session,
+        Func<PlayTimeSession, bool>? overlapsExistingSession = null)
+        : this(session, false, overlapsExistingSession)
+    {
+    }
+
+    public EditPlayTimeSessionDialog(
+        DateTime startedAt,
+        DateTime endedAt,
+        Func<PlayTimeSession, bool>? overlapsExistingSession = null)
+        : this(new PlayTimeSession
+        {
+            StartedAt = startedAt,
+            EndedAt = endedAt,
+            IsOpen = false,
+            Kind = PlayTimeSessionKind.Manual,
+            CountsTowardPlayTime = true,
+            ActivityIntervals =
+            [
+                new PlayTimeActivityInterval { StartedAt = startedAt, EndedAt = endedAt },
+            ],
+        }, true, overlapsExistingSession)
+    {
+    }
+
+    private EditPlayTimeSessionDialog(
+        PlayTimeSession session,
+        bool isNew,
+        Func<PlayTimeSession, bool>? overlapsExistingSession)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        _original = session.Clone();
+        _overlapsExistingSession = overlapsExistingSession;
+        InitializeComponent();
+        RequestedTheme = App.MainWindow?.Content is FrameworkElement element
+            ? element.RequestedTheme
+            : RequestedTheme;
+        XamlRoot = App.MainWindow!.Content.XamlRoot;
+        Title = (isNew ? "EditPlayTimeSessionDialog_AddTitle" : "EditPlayTimeSessionDialog_Title").GetLocalized();
+        PrimaryButtonText = "Yes".GetLocalized();
+        CloseButtonText = "Cancel".GetLocalized();
+        DefaultButton = ContentDialogButton.Primary;
+
+        StartDatePicker.Date = new DateTimeOffset(_original.StartedAt.Date);
+        SetTime(StartHourBox, StartMinuteBox, StartSecondBox, _original.StartedAt);
+        EndDatePicker.Date = new DateTimeOffset(_original.EndedAt.Date);
+        SetTime(EndHourBox, EndMinuteBox, EndSecondBox, _original.EndedAt);
+        PrimaryButtonClick += ValidateAndBuildResult;
+    }
+
+    private void ValidateAndBuildResult(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    {
+        if (StartDatePicker.Date is not { } startDate || EndDatePicker.Date is not { } endDate)
+        {
+            ShowValidation("EditPlayTimeSessionDialog_DateRequired".GetLocalized());
+            args.Cancel = true;
+            return;
+        }
+
+        DateTime start = startDate.LocalDateTime.Date + ReadTime(StartHourBox, StartMinuteBox, StartSecondBox);
+        DateTime end = endDate.LocalDateTime.Date + ReadTime(EndHourBox, EndMinuteBox, EndSecondBox);
+        if (end <= start)
+        {
+            ShowValidation("EditPlayTimeSessionDialog_EndBeforeStart".GetLocalized());
+            args.Cancel = true;
+            return;
+        }
+
+        Result = _original.Clone();
+        Result.StartedAt = start;
+        Result.EndedAt = end;
+        Result.IsOpen = false;
+        if (start != _original.StartedAt || end != _original.EndedAt)
+        {
+            Result.ActivityIntervals =
+            [
+                new PlayTimeActivityInterval { StartedAt = start, EndedAt = end },
+            ];
+        }
+        if (_overlapsExistingSession?.Invoke(Result) == true)
+        {
+            Result = null;
+            ShowValidation("EditPlayTimeSessionDialog_Overlap".GetLocalized());
+            args.Cancel = true;
+        }
+    }
+
+    private static void SetTime(NumberBox hourBox, NumberBox minuteBox, NumberBox secondBox, DateTime value)
+    {
+        hourBox.Value = value.Hour;
+        minuteBox.Value = value.Minute;
+        secondBox.Value = value.Second;
+    }
+
+    private static TimeSpan ReadTime(NumberBox hourBox, NumberBox minuteBox, NumberBox secondBox)
+    {
+        int hour = ReadPart(hourBox, 23);
+        int minute = ReadPart(minuteBox, 59);
+        int second = ReadPart(secondBox, 59);
+        return new TimeSpan(hour, minute, second);
+    }
+
+    private static int ReadPart(NumberBox box, int maximum)
+    {
+        if (double.IsNaN(box.Value)) return 0;
+        return Math.Clamp((int)box.Value, 0, maximum);
+    }
+
+    private void ShowValidation(string message)
+    {
+        ValidationMessage.Text = message;
+        ValidationMessage.Visibility = Visibility.Visible;
+    }
+
+    private void DialogContentRoot_OnPointerPressed(object sender, PointerRoutedEventArgs args)
+    {
+        if (args.OriginalSource is not DependencyObject source) return;
+        for (DependencyObject? current = source;
+             current is not null && !ReferenceEquals(current, sender);
+             current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is Microsoft.UI.Xaml.Controls.Control) return;
+        }
+        Focus(FocusState.Programmatic);
+    }
+}

--- a/GalgameManager/Views/GalgameSettingPage.xaml
+++ b/GalgameManager/Views/GalgameSettingPage.xaml
@@ -177,6 +177,14 @@
                                              ToolTipService.ToolTip="就把他当成cmd来用就行了" />
                                 </Grid>
                             </control:Panel>
+                            <!-- 启动弹窗期间暂不计时 -->
+                            <control:Panel Visibility="{x:Bind ViewModel.IsLocalGame, Mode=OneWay}">
+                                <control:Setting x:Uid="GalgameSettingPage_DelayPlayTimeUntilMainWindow">
+                                    <ToggleSwitch
+                                        IsOn="{x:Bind ViewModel.SelectedInstallationConfig.DelayPlayTimeUntilMainWindow,
+                                        Mode=TwoWay, FallbackValue=False}" />
+                                </control:Setting>
+                            </control:Panel>
                             <!-- 后台时静音游戏 -->
                             <control:Panel>
                                 <Grid ColumnDefinitions="Auto,*,Auto">

--- a/GalgameManager/Views/PlayedTimePage.xaml
+++ b/GalgameManager/Views/PlayedTimePage.xaml
@@ -18,7 +18,6 @@
     <Grid Margin="{ThemeResource PageButtonMargin}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         
@@ -28,42 +27,309 @@
             </core:EventTriggerBehavior>
         </interactivity:Interaction.Behaviors>
         
-        <TextBlock Grid.Row="0" Text="{x:Bind ViewModel.Game.Name.Value}" Style="{ThemeResource TitleTextBlockStyle}"/>
+        <Grid Grid.Row="0" ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="{x:Bind ViewModel.Game.Name.Value}"
+                       Style="{ThemeResource TitleTextBlockStyle}"
+                       TextTrimming="CharacterEllipsis"
+                       MaxLines="1"
+                       VerticalAlignment="Center"
+                       ToolTipService.ToolTip="{x:Bind ViewModel.Game.Name.Value}"/>
 
-        <CommandBar  Grid.Row="1" Background="Transparent" DefaultLabelPosition="Right"  Margin="0 -40 0 0">
-            <AppBarButton x:Uid="Back" Command="{x:Bind ViewModel.BackCommand}"
-                          AllowFocusOnInteraction="True">
-                <AppBarButton.Icon>
-                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72B;"/>
-                </AppBarButton.Icon>
-            </AppBarButton>
-            <AppBarButton x:Uid="Edit" Command="{x:Bind ViewModel.EditCommand}"
-                          AllowFocusOnInteraction="True">
-                <AppBarButton.Icon>
-                    <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE70F;"/>
-                </AppBarButton.Icon>
-            </AppBarButton>
-        </CommandBar>
+            <CommandBar Grid.Column="1"
+                        Background="Transparent"
+                        DefaultLabelPosition="Right"
+                        HorizontalAlignment="Right">
+                <AppBarButton x:Uid="Back" Command="{x:Bind ViewModel.BackCommand}"
+                              AllowFocusOnInteraction="True">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE72B;"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarToggleButton x:Uid="PlayedTimePage_RecordingMode"
+                                    Label="{x:Bind ViewModel.RecordingModeLabel, Mode=OneWay}"
+                                    IsChecked="{x:Bind ViewModel.PrecisePlayTimeEnabled, Mode=OneWay}"
+                                    Command="{x:Bind ViewModel.ToggleRecordingModeCommand}"
+                                    AllowFocusOnInteraction="True">
+                    <AppBarToggleButton.Icon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE916;"/>
+                    </AppBarToggleButton.Icon>
+                </AppBarToggleButton>
+                <AppBarButton x:Uid="PlayedTimePage_DateSort"
+                              Label="{x:Bind ViewModel.DateSortLabel, Mode=OneWay}"
+                              Command="{x:Bind ViewModel.ToggleDateSortCommand}"
+                              AllowFocusOnInteraction="True">
+                    <AppBarButton.Icon>
+                        <SymbolIcon Symbol="Sort"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton x:Uid="Edit" Command="{x:Bind ViewModel.EditCommand}"
+                              AllowFocusOnInteraction="True">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE70F;"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton x:Uid="PlayedTimePage_AddSession"
+                              Command="{x:Bind ViewModel.AddSessionCommand}"
+                              Visibility="{x:Bind ViewModel.PreciseModeVisibility, Mode=OneWay}"
+                              AllowFocusOnInteraction="True">
+                    <AppBarButton.Icon>
+                        <SymbolIcon Symbol="Add"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+            </CommandBar>
+        </Grid>
 
-        <ScrollViewer Grid.Row="2" VerticalScrollMode="Auto" HorizontalScrollMode="Disabled"
+        <ScrollViewer x:Name="PlayedTimeScrollViewer"
+                      Grid.Row="1" VerticalScrollMode="Auto" HorizontalScrollMode="Disabled"
                       Margin="{ThemeResource MediumTopMargin}">
-            <ItemsRepeater ItemsSource="{x:Bind ViewModel.Items}"
-                           Layout="{StaticResource VerticalStackLayout}">
-                <ItemsRepeater.ItemTemplate>
-                    <DataTemplate x:DataType="viewModels:PlayTimeViewModelItem">
-                        <StackPanel Orientation="Horizontal" Spacing="5">
-                            <TextBlock Text="{x:Bind Date}" MinWidth="100" />
-                            <Rectangle Fill="{ThemeResource SystemAccentColor}"
-                                       Width="{x:Bind Width, Mode=OneWay}"
-                                       Height="24" HorizontalAlignment="Left" />
-                            <TextBlock
-                                Text="{x:Bind PlayTime, Mode=OneWay, 
-                                Converter={StaticResource TimeToDisplayTimeConverter}}" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ItemsRepeater.ItemTemplate>
-            </ItemsRepeater>
+            <StackPanel Spacing="12" Padding="0,0,12,80">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="5"
+                            Visibility="{x:Bind ViewModel.PreciseModeVisibility, Mode=OneWay}">
+                    <TextBlock Text="{x:Bind ViewModel.Summary, Mode=OneWay}"
+                               Style="{ThemeResource DescriptionTextStyle}"
+                               TextWrapping="Wrap"
+                               VerticalAlignment="Center"/>
+                    <Button x:Uid="PlayedTimePage_PreciseTotalHelp"
+                            Width="24"
+                            Height="24"
+                            MinWidth="24"
+                            MinHeight="24"
+                            Padding="4"
+                            BorderThickness="0"
+                            CornerRadius="12"
+                            Background="Transparent"
+                            VerticalAlignment="Center">
+                        <Button.Flyout>
+                            <Flyout>
+                                <TextBlock x:Uid="PlayedTimePage_PreciseTotalHelpFlyout"
+                                           MaxWidth="320"
+                                           TextWrapping="Wrap"/>
+                            </Flyout>
+                        </Button.Flyout>
+                        <Border Width="16"
+                                Height="16"
+                                BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
+                                BorderThickness="1"
+                                CornerRadius="8">
+                            <TextBlock Text="?"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"/>
+                        </Border>
+                    </Button>
+                </StackPanel>
+                <TextBlock x:Uid="PlayedTimePage_SessionDescription"
+                           Visibility="{x:Bind ViewModel.PreciseModeVisibility, Mode=OneWay}"
+                           Style="{ThemeResource DescriptionTextStyle}"
+                           TextWrapping="Wrap"/>
+                <ItemsRepeater x:Name="PlayedTimeItemsRepeater"
+                               ItemsSource="{x:Bind ViewModel.Items}"
+                               Layout="{StaticResource VerticalStackLayout}">
+                    <ItemsRepeater.ItemTemplate>
+                        <DataTemplate x:DataType="viewModels:PlayTimeDayViewModelItem">
+                            <Grid>
+                                <Expander HorizontalContentAlignment="Stretch"
+                                          IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
+                                          Visibility="{x:Bind PreciseVisibility, Mode=OneWay}"
+                                          Margin="0,0,0,8">
+                                <Expander.Header>
+                                    <Grid ColumnSpacing="12" MinHeight="42">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{x:Bind Date, Mode=OneWay}"
+                                                   VerticalAlignment="Center"
+                                                   FontWeight="SemiBold"/>
+                                        <ItemsControl Grid.Column="1"
+                                                      ItemsSource="{x:Bind Segments}"
+                                                      Width="{x:Bind Width, Mode=OneWay}"
+                                                      HorizontalAlignment="Left">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Orientation="Horizontal"/>
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="viewModels:PlayTimeBarSegmentViewModelItem">
+                                                    <Grid Width="{x:Bind Width, Mode=OneWay}"
+                                                          Height="22"
+                                                          Margin="0,0,2,0">
+                                                        <Rectangle Fill="{ThemeResource SystemAccentColor}"
+                                                                   Opacity="{x:Bind Opacity}"
+                                                                   ToolTipService.ToolTip="{x:Bind ToolTip}"/>
+                                                        <Button Width="{x:Bind Width, Mode=OneWay}"
+                                                                Height="22"
+                                                                MinWidth="0"
+                                                                MinHeight="0"
+                                                                Padding="0"
+                                                                BorderThickness="0"
+                                                                CornerRadius="0"
+                                                                Background="Transparent"
+                                                                HorizontalContentAlignment="Stretch"
+                                                                VerticalContentAlignment="Stretch"
+                                                                Visibility="{x:Bind InteractiveVisibility}"
+                                                                ToolTipService.ToolTip="{x:Bind ToolTip}"
+                                                                AutomationProperties.Name="{x:Bind ToolTip}"
+                                                                Tapped="ActivateBarSegment"/>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{x:Bind TotalText, Mode=OneWay}"
+                                                   VerticalAlignment="Center"
+                                                   FontWeight="SemiBold"
+                                                   RightTapped="ChangeTimeFormat"/>
+                                    </Grid>
+                                </Expander.Header>
+                                <StackPanel Spacing="8" Padding="12,8,4,10">
+                                    <TextBlock Text="{x:Bind LegacyText, Mode=OneWay}"
+                                               Style="{ThemeResource DescriptionTextStyle}"
+                                               TextWrapping="Wrap"/>
+                                    <ItemsRepeater ItemsSource="{x:Bind Sessions}">
+                                        <ItemsRepeater.ItemTemplate>
+                                            <DataTemplate x:DataType="viewModels:PlayTimeSessionViewModelItem">
+                                                <Expander HorizontalContentAlignment="Stretch"
+                                                          IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}">
+                                                    <Expander.Header>
+                                                        <Grid ColumnSpacing="12" MinHeight="42">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="180"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="{x:Bind TimeRange, Mode=OneWay}"
+                                                                       VerticalAlignment="Center"
+                                                                       FontWeight="SemiBold"/>
+                                                            <TextBlock Grid.Column="1"
+                                                                       Text="{x:Bind Kind, Mode=OneWay}"
+                                                                       VerticalAlignment="Center"
+                                                                       Style="{ThemeResource DescriptionTextStyle}"/>
+                                                            <TextBlock Grid.Column="2"
+                                                                       Text="{x:Bind Duration, Mode=OneWay}"
+                                                                       VerticalAlignment="Center"
+                                                                       RightTapped="ChangeTimeFormat"/>
+                                                            <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4">
+                                                                <Button x:Uid="PlayedTimePage_EditSession"
+                                                                        Command="{x:Bind EditCommand}"
+                                                                        Visibility="{x:Bind EditVisibility, Mode=OneWay}">
+                                                                    <SymbolIcon Symbol="Edit"/>
+                                                                </Button>
+                                                                <Button x:Uid="PlayedTimePage_CloseSession"
+                                                                        Command="{x:Bind CloseCommand}"
+                                                                        Visibility="{x:Bind CloseVisibility, Mode=OneWay}">
+                                                                    <FontIcon Glyph="&#xE73E;"/>
+                                                                </Button>
+                                                                <Button x:Uid="PlayedTimePage_DeleteSession"
+                                                                        Command="{x:Bind DeleteCommand}"
+                                                                        Visibility="{x:Bind DeleteVisibility, Mode=OneWay}">
+                                                                    <SymbolIcon Symbol="Delete"/>
+                                                                </Button>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Expander.Header>
+                                                    <StackPanel Spacing="6" Padding="20,2,4,10">
+                                                        <TextBlock x:Uid="PlayedTimePage_ActivityIntervals"
+                                                                   Style="{ThemeResource DescriptionTextStyle}"/>
+                                                        <TextBlock x:Uid="PlayedTimePage_NoActivityIntervals"
+                                                                   Visibility="{x:Bind EmptyActivityVisibility, Mode=OneWay}"
+                                                                   Style="{ThemeResource DescriptionTextStyle}"/>
+                                                        <ItemsRepeater ItemsSource="{x:Bind ActivityIntervals}">
+                                                            <ItemsRepeater.ItemTemplate>
+                                                                <DataTemplate x:DataType="viewModels:PlayTimeActivityViewModelItem">
+                                                                    <Grid ColumnSpacing="12" MinHeight="32">
+                                                                        <Grid.ColumnDefinitions>
+                                                                            <ColumnDefinition Width="180"/>
+                                                                            <ColumnDefinition Width="Auto"/>
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <TextBlock Text="{x:Bind TimeRange}"
+                                                                                   VerticalAlignment="Center"/>
+                                                                        <TextBlock Grid.Column="1"
+                                                                                   Text="{x:Bind Duration}"
+                                                                                   VerticalAlignment="Center"
+                                                                                   RightTapped="ChangeTimeFormat"/>
+                                                                    </Grid>
+                                                                </DataTemplate>
+                                                            </ItemsRepeater.ItemTemplate>
+                                                        </ItemsRepeater>
+                                                    </StackPanel>
+                                                </Expander>
+                                            </DataTemplate>
+                                        </ItemsRepeater.ItemTemplate>
+                                    </ItemsRepeater>
+                                </StackPanel>
+                                </Expander>
+                                <StackPanel Visibility="{x:Bind MinuteVisibility, Mode=OneWay}"
+                                            Orientation="Horizontal"
+                                            Spacing="5">
+                                    <TextBlock Text="{x:Bind Date, Mode=OneWay}" MinWidth="100"
+                                               VerticalAlignment="Center"/>
+                                    <ItemsControl ItemsSource="{x:Bind Segments}"
+                                                  Width="{x:Bind Width, Mode=OneWay}"
+                                                  HorizontalAlignment="Left">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="viewModels:PlayTimeBarSegmentViewModelItem">
+                                                <Button Width="{x:Bind Width, Mode=OneWay}"
+                                                        Height="24"
+                                                        MinWidth="0"
+                                                        MinHeight="0"
+                                                        Padding="0"
+                                                        Margin="0,0,2,0"
+                                                        BorderThickness="0"
+                                                        CornerRadius="0"
+                                                        Background="Transparent"
+                                                        HorizontalContentAlignment="Stretch"
+                                                        VerticalContentAlignment="Stretch"
+                                                        Command="{x:Bind ActivateCommand}"
+                                                        ToolTipService.ToolTip="{x:Bind ToolTip}"
+                                                        AutomationProperties.Name="{x:Bind ToolTip}">
+                                                    <Rectangle Fill="{ThemeResource SystemAccentColor}"
+                                                               Opacity="{x:Bind Opacity}"/>
+                                                </Button>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock Text="{x:Bind TotalText, Mode=OneWay}"
+                                               VerticalAlignment="Center"
+                                               RightTapped="ChangeTimeFormat"/>
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsRepeater.ItemTemplate>
+                </ItemsRepeater>
+            </StackPanel>
         </ScrollViewer>
+
+        <Button x:Uid="PlayedTimePage_Refresh"
+                Grid.Row="1"
+                Width="44"
+                Height="44"
+                MinWidth="44"
+                MinHeight="44"
+                Padding="0"
+                Margin="0,0,24,24"
+                CornerRadius="22"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Click="RefreshPlayedTime"
+                Canvas.ZIndex="1">
+            <SymbolIcon Symbol="Refresh"/>
+        </Button>
     </Grid>
     
 </Page>

--- a/GalgameManager/Views/PlayedTimePage.xaml.cs
+++ b/GalgameManager/Views/PlayedTimePage.xaml.cs
@@ -15,5 +15,90 @@ namespace GalgameManager.Views
             InitializeComponent();
             DataContext = ViewModel;
         }
+
+        private void ChangeTimeFormat(object sender, Microsoft.UI.Xaml.Input.RightTappedRoutedEventArgs e)
+        {
+            e.Handled = true;
+            if (ViewModel.ChangeTimeFormatCommand.CanExecute(null))
+                ViewModel.ChangeTimeFormatCommand.Execute(null);
+        }
+
+        private void ActivateBarSegment(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
+        {
+            e.Handled = true;
+            if (sender is not Microsoft.UI.Xaml.FrameworkElement
+                {
+                    DataContext: PlayTimeBarSegmentViewModelItem segment
+                }) return;
+            if (segment.ActivateCommand.CanExecute(null))
+                segment.ActivateCommand.Execute(null);
+        }
+
+        private void RefreshPlayedTime(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            ScrollAnchor? anchor = CaptureScrollAnchor();
+            double fallbackOffset = PlayedTimeScrollViewer.VerticalOffset;
+            if (!ViewModel.RefreshCommand.CanExecute(null)) return;
+
+            ViewModel.RefreshCommand.Execute(null);
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                PlayedTimeScrollViewer.UpdateLayout();
+                if (anchor is { } value &&
+                    TryGetDayElement(value.Date, out Microsoft.UI.Xaml.FrameworkElement? day) &&
+                    day is not null)
+                {
+                    double currentY = day.TransformToVisual(PlayedTimeScrollViewer)
+                        .TransformPoint(new Windows.Foundation.Point()).Y;
+                    PlayedTimeScrollViewer.ChangeView(
+                        null,
+                        Math.Clamp(PlayedTimeScrollViewer.VerticalOffset + currentY - value.ViewportY,
+                            0,
+                            PlayedTimeScrollViewer.ScrollableHeight),
+                        null,
+                        true);
+                    return;
+                }
+                PlayedTimeScrollViewer.ChangeView(
+                    null,
+                    Math.Min(fallbackOffset, PlayedTimeScrollViewer.ScrollableHeight),
+                    null,
+                    true);
+            });
+        }
+
+        private ScrollAnchor? CaptureScrollAnchor()
+        {
+            ScrollAnchor? result = null;
+            double closestY = double.MaxValue;
+            for (int index = 0; index < ViewModel.Items.Count; index++)
+            {
+                if (PlayedTimeItemsRepeater.TryGetElement(index) is not Microsoft.UI.Xaml.FrameworkElement element)
+                    continue;
+                double y = element.TransformToVisual(PlayedTimeScrollViewer)
+                    .TransformPoint(new Windows.Foundation.Point()).Y;
+                double bottom = y + element.ActualHeight;
+                if (bottom <= 0 || y >= PlayedTimeScrollViewer.ViewportHeight) continue;
+                double distance = Math.Abs(Math.Max(0, y));
+                if (distance >= closestY) continue;
+                closestY = distance;
+                result = new ScrollAnchor(ViewModel.Items[index].DateValue, y);
+            }
+            return result;
+        }
+
+        private bool TryGetDayElement(DateTime date, out Microsoft.UI.Xaml.FrameworkElement? element)
+        {
+            for (int index = 0; index < ViewModel.Items.Count; index++)
+            {
+                if (ViewModel.Items[index].DateValue != date) continue;
+                element = PlayedTimeItemsRepeater.TryGetElement(index) as Microsoft.UI.Xaml.FrameworkElement;
+                return element is not null;
+            }
+            element = null;
+            return false;
+        }
+
+        private readonly record struct ScrollAnchor(DateTime Date, double ViewportY);
     }
 }

--- a/GalgameManager/Views/SettingsPage.xaml
+++ b/GalgameManager/Views/SettingsPage.xaml
@@ -368,6 +368,12 @@
                                     x:Uid="SettingsPage_Game_RecordOnlyForeground"
                                     IsOn="{x:Bind ViewModel.RecordOnlyForeground, Mode=TwoWay}"/>
                             </control:Panel>
+                            <!-- 秒级游玩计时 -->
+                            <control:Panel>
+                                <local:SettingToggleSwitch
+                                    x:Uid="SettingsPage_Game_PrecisePlayTime"
+                                    IsOn="{x:Bind ViewModel.PrecisePlayTime, Mode=TwoWay}"/>
+                            </control:Panel>
                             <!-- 游玩时窗口状态 -->
                             <control:Panel>
                                 <control:Setting x:Uid="SettingsPage_Game_PlayingWindowMode">


### PR DESCRIPTION
> 依赖 #725，并传递依赖 #718；#719 已合并。当前本地分支直接叠在进程接力分支上，前置 PR 合并后本 PR 的差异会自动收敛为秒级计时功能本身。如果合并的话建议按顺序合并。

#709 希望把每天的游玩时间拆成多段显示，并允许单独修改某一次游玩。目前 PotatoVN 只保存按日期汇总的整数分钟，无法知道一天内分别进行了几次游玩，也无法只修正其中一段记录。

这次在保留原版分钟采样和旧数据兼容的基础上，增加原生的逐次启动记录，并让“显示精确游玩时间”同时控制采集、显示和编辑模式：

- 关闭精确模式时仍按原版每 60 秒采样一次，并使用原版风格的分钟显示和编辑。每次启动会保存独立的分钟贡献，用分节柱状图表示；悬停可查看单段时长，单击可只编辑或删除这一次启动在当天贡献的分钟数。
- 开启精确模式时，每次确认进入游戏后创建一条外层启动记录，记录本次启动的开始、结束、安装实例和开放状态；直到游戏进程结束才关闭。同一次启动中的前后台切换只会暂停或恢复内部有效计时片段，不会拆成多个外层记录。
- 精确模式按秒生成逐日汇总，日期卡片可展开查看每次启动的精确起止时间、持续时长和内部有效计时片段。已结束的记录可以精确到秒编辑、手工新增或删除。
- 跨日启动会按日期拆分柱状图贡献。分钟模式只修改或删除所选日期的贡献；精确模式从任意日期切片进入时，仍编辑或删除完整的跨日启动记录。
- 正在记录的时段不会被直接编辑或删除；异常退出留下的开放时段可以在确认后手动结束。
- 旧版只有分钟汇总的数据继续保留，并在详情页中作为没有起止边界的历史汇总显示，不会为它伪造启动时间。
- 一次游戏启动时会锁定本次采集模式；运行中切换开关从下一次启动生效，不会让同一条记录混用分钟和秒级规则。

分钟模式沿用原版的逐日分钟编辑界面；精确模式显示小时、分钟和秒。日汇总允许大于已分段记录总和，多出的部分作为没有起止边界的历史或手工余量；日汇总不能小于分段记录总和，需要缩短时应先编辑或删除对应记录。

精确模式根据当前完整有效区间计算累计差额。这样即使采样受系统调度影响，日期汇总也不会逐渐偏离详情页显示的时段长度。

页面支持按日期正序或倒序排列，并记住用户选择；右下角刷新会原地同步现有数据，保留日期、内部记录的展开状态和当前浏览位置。分钟模式与精确模式之间切换时会同步刷新卡片模板和星期显示；既有的分钟分段和精确记录都会保留，不会合并成无法单独操作的历史汇总。秒级记录投影到分钟界面时仍按启动分段，不足一分钟的正数记录显示为“不足 1 分钟”，单击后继续编辑完整的秒级启动记录，不会把底层边界降级成分钟。

精确模式顶部另行显示包含每日秒级余量的真实累计秒数，不改变原版 `TotalPlayTime` 按每天整分钟相加的兼容语义。总计旁的带圈问号可悬停或单击，说明两种累计口径为何可能存在差值；整个 24×24 按钮区域都参与命中测试。

旧 `PlayedTime` 和 `TotalPlayTime` 仍由新数据生成，旧版本和现有云同步可以继续读取分钟汇总。应用自己的数据导出包会一并保存逐次启动记录和内部有效片段，重新导入后不会丢失这些详情；只经过旧客户端或只同步分钟字段的云端往返时，精确详情无法保留。

## 界面预览

分钟模式保留原版简洁布局，同时把每次启动显示为可单独操作的分段（顺便小修了游戏名过长时会覆盖按钮的bug）：
<img width="1179" height="744" alt="图片" src="https://github.com/user-attachments/assets/1bef588b-312c-4a49-b19f-140f3f3ca39a" />

<img width="1127" height="155" alt="图片" src="https://github.com/user-attachments/assets/c41d311c-ba97-4c09-a3e6-23e2f47bea6c" />

秒级模式显示精确时长、模式联动、日期排序和右下角刷新入口：

<img width="1166" height="744" alt="图片" src="https://github.com/user-attachments/assets/394279f9-67c8-4106-b124-494da2a50223" />

## 验证

已补充分钟采样、模式锁定、连续秒级采样、一次启动内多段前台累计、跨日累计、手工新增、时段编辑与删除、开放时段保护、旧分钟兼容、分钟与秒级记录双向投影、不足一分钟显示、极值饱和保护、精确总计、序列化、导入合并和旧偏差校正测试。x64 Release/XAML 构建正常。

本地测试已覆盖分钟／精确模式切换、同日多次游玩、仅前台计时、跨日、编辑、删除、手工新增、异常开放时段修复、游戏运行中编辑记录受阻、导出后重新导入、日期排序、长列表原地刷新、模式切换后的卡片与星期刷新、两种记录在两种界面中的独立分段、日期排序在应用重启后保持，以及精确总计帮助按钮的悬停和单击。