### PR TITLE
fix: 修复冷启动阶段插件未就绪导致Bangumi代理失效、误报Token过期及游玩状态同步失败

### DIFF
--- a/GalgameManager/Helpers/Phrase/BgmPhraser.cs
+++ b/GalgameManager/Helpers/Phrase/BgmPhraser.cs
@@ -21,6 +21,7 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
     private string _userId = string.Empty;
     private string _userName = string.Empty;
     private Task? _checkAuthTask;
+    private string _token = string.Empty;
 
     public BgmPhraser(BgmPhraserData data)
     {
@@ -37,20 +38,20 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
     private void GetHttpClient(BgmPhraserData data)
     {
         _authed = false;
-        var bgmToken = data.Token;
+        _token = data.Token ?? string.Empty;
         _httpClient = Utils.GetDefaultHttpClient().WithApplicationJson();
-        _bgmApi = BgmApi.GetApi(bgmToken);
-        if (!string.IsNullOrEmpty(bgmToken))
+        _bgmApi = BgmApi.GetApi(_token);
+        if (!string.IsNullOrEmpty(_token))
         {
-            _httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + bgmToken);
-            _checkAuthTask = Task.Run(() =>
+            _httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + _token);
+            _checkAuthTask = Task.Run(async () =>
             {
                 try
                 {
-                    HttpResponseMessage response = _httpClient.GetAsync("https://api.bgm.tv/v0/me").Result;
+                    HttpResponseMessage response = await _httpClient.GetAsync("https://api.bgm.tv/v0/me");
                     _authed = response.IsSuccessStatusCode;
                     if (!_authed) return;
-                    JObject json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+                    JObject json = JObject.Parse(await response.Content.ReadAsStringAsync());
                     _userId = json["id"]!.ToString();
                     _userName = json["username"]!.ToString();
                 }
@@ -59,6 +60,36 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
                     //ignore
                 }
             });
+        }
+    }
+
+    private async Task<bool> EnsureAuthAsync()
+    {
+        if (_checkAuthTask != null)
+        {
+            try { await _checkAuthTask; } catch { /* ignore */ }
+        }
+        if (_authed && !string.IsNullOrEmpty(_userId)) return true;
+        if (string.IsNullOrEmpty(_token)) return false;
+
+        try
+        {
+            _httpClient = Utils.GetDefaultHttpClient().WithApplicationJson();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", "Bearer " + _token);
+            _bgmApi = BgmApi.GetApi(_token);
+
+            HttpResponseMessage response = await _httpClient.GetAsync("https://api.bgm.tv/v0/me");
+            _authed = response.IsSuccessStatusCode;
+            if (!_authed) return false;
+            JObject json = JObject.Parse(await response.Content.ReadAsStringAsync());
+            _userId = json["id"]!.ToString();
+            _userName = json["username"]!.ToString();
+            return true;
+        }
+        catch (Exception)
+        {
+            _authed = false;
+            return false;
         }
     }
     
@@ -371,8 +402,7 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
 
     public async Task<(GalStatusSyncResult, string)> UploadAsync(Galgame galgame)
     {
-        if (_checkAuthTask != null) await _checkAuthTask;
-        if (_authed == false)
+        if (await EnsureAuthAsync() == false)
             return (GalStatusSyncResult.UnAuthorized, "BgmPhraser_UploadAsync_UnAuthorized".GetLocalized());
         if (string.IsNullOrEmpty(galgame.Ids[(int)RssType.Bangumi]))
             return (GalStatusSyncResult.NoId, "BgmPhraser_UploadAsync_NoId".GetLocalized());
@@ -392,7 +422,7 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
             response = await _httpClient.PostAsync($"https://api.bgm.tv/v0/users/-/collections/{galgame.Ids[(int)RssType.Bangumi]}", content);
             if (response.IsSuccessStatusCode == false)
             {
-                JObject json = JObject.Parse(response.Content.ReadAsStringAsync().Result);
+                JObject json = JObject.Parse(await response.Content.ReadAsStringAsync());
                 error = json["description"]!.ToString();
             }
         }
@@ -408,8 +438,7 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
 
     public async Task<(GalStatusSyncResult, string)> DownloadAsync(Galgame galgame)
     {
-        if (_checkAuthTask != null) await _checkAuthTask;
-        if (_authed == false) 
+        if (await EnsureAuthAsync() == false) 
             return (GalStatusSyncResult.UnAuthorized, "BgmPhraser_UploadAsync_UnAuthorized".GetLocalized());
         if (string.IsNullOrEmpty(galgame.Ids[(int)RssType.Bangumi]))
             return (GalStatusSyncResult.NoId, "BgmPhraser_UploadAsync_NoId".GetLocalized());
@@ -433,8 +462,7 @@ public class BgmPhraser : IGalInfoPhraser, IGalStatusSync, IGalCharacterPhraser,
 
     public async Task<(GalStatusSyncResult, string)> DownloadAllAsync(IList<Galgame> galgames)
     {
-        if (_checkAuthTask is not null) await _checkAuthTask;
-        if (_authed == false) return (GalStatusSyncResult.UnAuthorized, "BgmPhraser_UploadAsync_UnAuthorized".GetLocalized());
+        if (await EnsureAuthAsync() == false) return (GalStatusSyncResult.UnAuthorized, "BgmPhraser_UploadAsync_UnAuthorized".GetLocalized());
         int offset = 0, total = -1, cnt = 0;
         GalStatusSyncResult result = GalStatusSyncResult.Ok;
         var msg = string.Empty;

--- a/GalgameManager/Services/AccountServices/BgmOAuthService.cs
+++ b/GalgameManager/Services/AccountServices/BgmOAuthService.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Foundation;
+using Windows.Foundation;
 using Windows.System;
 using GalgameManager.Contracts.Services;
 using GalgameManager.Enums;
@@ -20,6 +20,8 @@ public class BgmOAuthService : IBgmOAuthService
     private readonly IConfiguration _config;
     private readonly TimeSpan _minRefreshTime = new(2, 0, 0, 0);
     private bool _isInitialized;
+    
+    private bool _lastRefreshNetworkError;
     
     public event Action<BgmOAuthStatus>? OnAuthResultChange;
 
@@ -46,8 +48,8 @@ public class BgmOAuthService : IBgmOAuthService
                 // Try to refresh the token and check if it's valid
                 bool refreshSuccess = await RefreshAccountAsync();
                 
-                // If refresh failed, it means the refresh token is invalid/expired
-                if (!refreshSuccess)
+                // If refresh failed due to token invalidation (not temporary network/server error)
+                if (!refreshSuccess && !_lastRefreshNetworkError)
                 {
                     // Notify user that they need to logout and login again
                     _infoService.Event(EventType.BgmOAuthEvent, InfoBarSeverity.Warning,
@@ -150,6 +152,7 @@ public class BgmOAuthService : IBgmOAuthService
     
     public async Task<bool> RefreshAccountAsync()
     {
+        _lastRefreshNetworkError = false;
         BgmAccount? account = await _localSettingsService.ReadSettingAsync<BgmAccount>(KeyValues.BangumiAccount);
         if (string.IsNullOrEmpty(account?.BangumiRefreshToken)) return false;
         HttpClient client = GetHttpClient();
@@ -158,7 +161,14 @@ public class BgmOAuthService : IBgmOAuthService
             HttpResponseMessage response = await client.GetAsync(new Uri(await BaseUriAsync(), 
                 "bangumi/refresh").AddQuery("refreshToken", account.BangumiRefreshToken));
             if (response.IsSuccessStatusCode == false)
+            {
+                // 仅当明确返回 4xx 时才视为 Token 失效；5xx 或网关超时等属于临时网络/服务端异常
+                if ((int)response.StatusCode >= 500)
+                {
+                    _lastRefreshNetworkError = true;
+                }
                 throw new Exception(await response.Content.ReadAsStringAsync());
+            }
             JObject json = JObject.Parse(await response.Content.ReadAsStringAsync());
             account.BangumiAccessToken = json["token"]!.ToString();
             account.BangumiRefreshToken = json["refreshToken"]!.ToString();
@@ -168,7 +178,11 @@ public class BgmOAuthService : IBgmOAuthService
         }
         catch(Exception e)
         {
-            _infoService.Event(EventType.BgmOAuthEvent, e is HttpRequestException ? InfoBarSeverity.Warning 
+            if (e is HttpRequestException or TaskCanceledException or TimeoutException or OperationCanceledException)
+            {
+                _lastRefreshNetworkError = true;
+            }
+            _infoService.Event(EventType.BgmOAuthEvent, e is HttpRequestException or TaskCanceledException ? InfoBarSeverity.Warning 
                     :InfoBarSeverity.Error, "BgmOAuthService_RefreshFailed".GetLocalized(), e);
             return false;
         }
@@ -247,7 +261,7 @@ public class BgmOAuthService : IBgmOAuthService
         _pvnService ??= App.GetService<IPvnService>();
         PvnServerInfo? serverInfo = await _pvnService.GetServerInfoAsync();
         if (serverInfo?.BangumiOauth2Enable == true) return _pvnService.BaseUri;
-        return new Uri(_config["PotatoVNOfficialServer"]!);
+        return new Uri(_config["Urls:PotatoVNOfficialServer"]!);
     }
 
     private static HttpClient GetHttpClient()

--- a/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
+++ b/GalgameManager/Services/GalgameCollectionService/GalgameCollectionService.cs
@@ -1074,16 +1074,21 @@ public partial class GalgameCollectionService : IGalgameCollectionService
         }
     }
 
-    private void OnPluginLoaded(object recipient, PluginLoadArgs message)
+    private async void OnPluginLoaded(object recipient, PluginLoadArgs message)
     {
         try
         {
             // ReSharper disable once SuspiciousTypeConversion.Global
-            if (message.Plugin is not IParserProvider provider) return;
-            IGalInfoPhraser parser = provider.GetPhraser();
-            RssType type = parser.GetPhraseType();
-            PhraserList[(int)type] = parser;
-            EnumExtension.Register(type.GetType(), (int)type, provider.ParserName);
+            if (message.Plugin is IParserProvider provider)
+            {
+                IGalInfoPhraser parser = provider.GetPhraser();
+                RssType type = parser.GetPhraseType();
+                PhraserList[(int)type] = parser;
+                EnumExtension.Register(type.GetType(), (int)type, provider.ParserName);
+            }
+
+            // 插件加载后（可能包含网络代理插件注册了 DefaultProxy），刷新内置 Bangumi 数据源以应用最新代理
+            PhraserList[(int)RssType.Bangumi].UpdateData(await GetBgmData());
         }
         catch (Exception e)
         {

--- a/GalgameManager/Services/PluginService/PluginService.cs
+++ b/GalgameManager/Services/PluginService/PluginService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -147,34 +147,33 @@ public partial class PluginService(
 
     public async Task InitAsync()
     {
-        await Task.CompletedTask; //预留异步
         _pluginsDb = settingService.Database.GetCollection<PluginX>("plugin");
         _pluginDataDb = settingService.Database.GetCollection<PluginData>("plugin_data");
         PluginDir = new DirectoryInfo((await FileHelper.GetFolderAsync(FileHelper.FolderType.Plugins)).Path);
         if (!PluginDir.Exists) PluginDir.Create();
-        _ = Task.Run(async () =>
+
+        // 先完成插件升级再加载插件
+        try
         {
-            // 先完成插件升级再加载插件
-            try
-            {
-                List<ToInstallStorePlugin> list =
-                    await settingService.ReadSettingAsync<List<ToInstallStorePlugin>>(KeyValues.ToUpgradePlugin) ?? [];
-                List<Task> tasks = [];
-                foreach (ToInstallStorePlugin item in list)
-                    tasks.Add(bgTaskService.AddBgTask(new InstallStorePluginTask(item.Plugin, item.Version)));
-                await Task.WhenAll(tasks);
-            }
-            catch (Exception e)
-            {
-                infoService.Event(EventType.PluginError, InfoBarSeverity.Warning,
-                    "PluginService_UpgradePluginFailed".GetLocalized(), exception: e);
-            }
-            finally
-            {
-                await settingService.RemoveSettingAsync(KeyValues.ToUpgradePlugin);
-            }
-            _ = bgTaskService.AddBgTask(new LoadPluginTask());
-        });
+            List<ToInstallStorePlugin> list =
+                await settingService.ReadSettingAsync<List<ToInstallStorePlugin>>(KeyValues.ToUpgradePlugin) ?? [];
+            List<Task> tasks = [];
+            foreach (ToInstallStorePlugin item in list)
+                tasks.Add(bgTaskService.AddBgTask(new InstallStorePluginTask(item.Plugin, item.Version)));
+            await Task.WhenAll(tasks);
+        }
+        catch (Exception e)
+        {
+            infoService.Event(EventType.PluginError, InfoBarSeverity.Warning,
+                "PluginService_UpgradePluginFailed".GetLocalized(), exception: e);
+        }
+        finally
+        {
+            await settingService.RemoveSettingAsync(KeyValues.ToUpgradePlugin);
+        }
+
+        // 确保启动阶段所有已启用的插件（如网络代理/拦截插件）完成加载与初始化，避免后续服务在未就绪状态下发起请求
+        await bgTaskService.AddBgTask(new LoadPluginTask());
     }
 
     public async Task LoadPluginAsync(PluginX plugin, bool load)


### PR DESCRIPTION
## 问题

1. 启用了“Bangumi 专用代理”或类似网络代理插件时，应用冷启动后：
   - OAuth 登录账号刷新失败，并误弹出“登录过期，请退出后重新登录”；
   - API Key / AccessToken 登录账号在游戏界面同步游玩状态时，误报“尚未登录，需要在设置中登录Bangumi账号”；
   - 必须手动登出并重新登录才能代理上，重启应用后再次失效。
2. 降级使用官方服务器时，`BgmOAuthService.BaseUriAsync()` 因配置键错误抛出异常。

## 原因

1. **时序竞态**：`PluginService.InitAsync` 内部原使用 `_ = Task.Run(...)` 与 `_ = bgTaskService.AddBgTask(new LoadPluginTask())` 且未 `await`，方法提前返回导致下游服务在代理注入前即发起直连请求。
2. **提前实例化与静态代理捕获**：`GalgameCollectionService` 构造阶段即实例化 `BgmPhraser` 并异步请求 `https://api.bgm.tv/v0/me`。此时代理尚未加载，直连超时后将 `_authed` 永久置为 `false` 且无重试机制；同时其持有的 `_httpClient` 捕获了未配置代理的 Handler，后续全局 `DefaultProxy` 变更后该实例无法感知。
3. **激进的失效判定**：`BgmOAuthService.Init()` 将网络超时/中断等临时异常一律视为 Token 过期并弹出警告。
4. **配置键不一致**：`BgmOAuthService.BaseUriAsync()` 读取键为 `PotatoVNOfficialServer`，实际键名为 `Urls:PotatoVNOfficialServer`。

## 修改

- **PluginService**：规范 `await` 插件升级与 `LoadPluginTask`，确保已启用插件在后续启动服务运行前就绪。
- **BgmPhraser**：
  - 增加 `EnsureAuthAsync()` 自愈机制：在 `DownloadAsync` / `DownloadAllAsync` / `UploadAsync` 调用时若未通过认证，获取当前带代理的最新 `HttpClient` 重新就地校验，避免冷启动未连通导致后续同步永久失败。
  - 修复 `UploadAsync` 中未异步 await content 的问题。
- **GalgameCollectionService**：在 `OnPluginLoaded` 收到插件加载通知后，主动刷新内置 Bangumi 数据源以应用最新代理。
- **BgmOAuthService**：
  - 区分网络异常（`HttpRequestException`、超时、服务端 5xx）与客户端认证失效（4xx），避免临时网络故障误报 Token 过期。
  - 修正降级配置键为 `Urls:PotatoVNOfficialServer`。

## 测试

- 单元测试：`dotnet test GalgameManager.Test/GalgameManager.Test.csproj --filter TestCategory!=Phraser&FullyQualifiedName!~UnpackagedAppUpgradeUiTest`（151/151 全部通过）。
- 实机验证：在启用“Bangumi 专用代理”环境下验证冷启动，OAuth 登录保持有效，API Key 模式下重启后游戏游玩状态正常双向同步。